### PR TITLE
Fix all examples to run either from root or in examples dir

### DIFF
--- a/examples/attributes.py
+++ b/examples/attributes.py
@@ -50,7 +50,6 @@ def project():
 
 
 if __name__ == '__main__':
-    set_option('display.height', 1000)
     set_option('display.max_rows', 500)
     set_option('display.max_columns', 500)
     set_option('display.width', 1000)

--- a/examples/commit_history.py
+++ b/examples/commit_history.py
@@ -3,6 +3,8 @@ from gitpandas import ProjectDirectory, Repository
 import numpy as np
 from pandas import set_option
 
+from definitions import GIT_PANDAS_DIR
+
 __author__ = 'willmcginnis'
 
 
@@ -80,11 +82,10 @@ def repository(path):
     print(etns)
 
 if __name__ == '__main__':
-    set_option('display.height', 1000)
     set_option('display.max_rows', 500)
     set_option('display.max_columns', 500)
     set_option('display.width', 1000)
 
-    path = os.path.abspath('../../git-pandas')
+    path = os.path.abspath(GIT_PANDAS_DIR)
     project(path)
     repository(path)

--- a/examples/definitions.py
+++ b/examples/definitions.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+GIT_PANDAS_DIR = Path(__file__).resolve().parent.parent

--- a/examples/file_change_rates.py
+++ b/examples/file_change_rates.py
@@ -1,10 +1,12 @@
 import os
 from gitpandas import Repository
 
+from definitions import GIT_PANDAS_DIR
+
 __author__ = 'willmcginnis'
 
 
 if __name__ == '__main__':
-    repo = Repository(working_dir=os.path.abspath('../../git-pandas'))
+    repo = Repository(working_dir=GIT_PANDAS_DIR)
     fc = repo.file_change_rates(include_globs=['*.py'], coverage=True)
     print(fc)

--- a/examples/hours_estimate.py
+++ b/examples/hours_estimate.py
@@ -1,14 +1,14 @@
 import os
 from gitpandas.repository import Repository
 
+from definitions import GIT_PANDAS_DIR
+
 __author__ = 'willmcginnis'
 
-# get the path of this repo
-path = os.path.abspath('../../git-pandas')
 
 # build an example repository object and try some things out
 ignore_dirs = ['tests/*']
-r = Repository(path, verbose=True)
+r = Repository(GIT_PANDAS_DIR, verbose=True)
 
 # get the hours estimate for this repository (using 30 mins per commit)
 he = r.hours_estimate(

--- a/examples/parallel_blame.py
+++ b/examples/parallel_blame.py
@@ -1,11 +1,13 @@
 from gitpandas import Repository
 import time
 
+from definitions import GIT_PANDAS_DIR
+
 __author__ = 'willmcginnis'
 
 
 if __name__ == '__main__':
-    g = Repository(working_dir='..')
+    g = Repository(working_dir=GIT_PANDAS_DIR)
 
     st = time.time()
     blame = g.cumulative_blame(branch='master', include_globs=['*.py', '*.html', '*.sql', '*.md'], limit=None, skip=None)

--- a/examples/project_blame.py
+++ b/examples/project_blame.py
@@ -1,10 +1,12 @@
 import os
 from gitpandas import ProjectDirectory
 
+from definitions import GIT_PANDAS_DIR
+
 __author__ = 'willmcginnis'
 
 if __name__ == '__main__':
-    g = ProjectDirectory(working_dir=os.path.abspath('../'))
+    g = ProjectDirectory(working_dir=GIT_PANDAS_DIR)
 
     b = g.blame(include_globs=['*.py'], ignore_globs=['lib/*', 'docs/*'], by='file')
     print(b.head(5))

--- a/examples/punchcard.py
+++ b/examples/punchcard.py
@@ -5,7 +5,9 @@
 from gitpandas.utilities.plotting import plot_punchcard
 from gitpandas import ProjectDirectory
 
-g = ProjectDirectory(working_dir=[...], verbose=True)
+from definitions import GIT_PANDAS_DIR
+
+g = ProjectDirectory(working_dir=[str(GIT_PANDAS_DIR)], verbose=True)
 
 by = None
 punchcard = g.punchcard(branch='master', include_globs=['*.py'], by=by, normalize=2500)

--- a/examples/repo_file_detail.py
+++ b/examples/repo_file_detail.py
@@ -1,10 +1,12 @@
 import os
 from gitpandas import ProjectDirectory
 
+from definitions import GIT_PANDAS_DIR
+
 __author__ = 'willmcginnis'
 
 if __name__ == '__main__':
-    g = ProjectDirectory(working_dir=os.path.abspath('../'))
+    g = ProjectDirectory(working_dir=GIT_PANDAS_DIR)
 
     b = g.file_detail(include_globs=['*.py'], ignore_globs=['lib/*', 'docs/*'])
     print(b.head(25))

--- a/gitpandas/project.py
+++ b/gitpandas/project.py
@@ -395,7 +395,7 @@ class ProjectDirectory(object):
             except GitCommandError:
                 print('Warning! Repo: %s couldnt be inspected' % (repo, ))
 
-        df = df.reset_index(level=1)
+        df = df.reset_index(level=-1)
         df = df.set_index(['file', 'repository'])
         return df
 

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -920,13 +920,13 @@ class Repository(object):
             committer=committer,
             by='file'
         )
-        blame = blame.reset_index(level=1)
-        blame = blame.reset_index(level=1)
+        blame = blame.reset_index(level=-1)
+        blame = blame.reset_index(level=-1)
 
         # reduce it to files and total LOC
         df = blame.reindex(columns=['file', 'loc'])
         df = df.groupby('file').agg({'loc': np.sum})
-        df = df.reset_index(level=1)
+        df = df.reset_index(level=-1)
 
         # map in file owners
         df['file_owner'] = df['file'].map(lambda x: self.file_owner(rev, x, committer=committer))

--- a/gitpandas/utilities/plotting.py
+++ b/gitpandas/utilities/plotting.py
@@ -43,7 +43,7 @@ def plot_punchcard(df, metric='lines', title='punchcard', by=None):
         else:
             sub_df = df
         fig = plt.figure(figsize=(8, title and 3 or 2.5), facecolor='#ffffff')
-        ax = fig.add_subplot('111', facecolor='#ffffff')
+        ax = fig.add_subplot(111, facecolor='#ffffff')
         fig.subplots_adjust(left=0.06, bottom=0.04, right=0.98, top=0.95)
         if by is not None:
             ax.set_title(title + ' (%s)' % (str(val), ), y=0.96).set_color('#333333')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+-e .[examples]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,2 @@
 # Bare Minimum, to run tests add nose, to run some examples, add matplotlib
-gitpython>=1.0.0
-numpy>=1.9.0
-pandas>=0.16.0
-requests
-redis
+-e .

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,12 @@ setup(
     install_requires=[
         'gitpython>=1.0.0',
         'numpy>=1.9.0',
-        'pandas>=0.16.0'
+        'pandas>=0.16.0',
+        'requests',
+        'redis'
     ],
+    extras_require={
+        'examples': ['matplotlib', 'lifelines'],
+    },
     author_email='will@pedalwrencher.com'
 )


### PR DESCRIPTION
Fixed all errors in examples that were due to out dated code (pandas
issues with options and indexing). Also fixed it so that all the paths
that use git-pandas as the repo do it in a way that they can be ran
inside the examples directory or at the root directory. Part of doing
this was to better setup the setup.py file. All the requirements are now
in the setup.py, and the requirements.txt file says to `-e .` so that it
install git-pandas in the local envirornment in editable mode. The
normal reccomended way for package development. And then also added an
optional extra dependencies section and added examples dependencies like
matplotlib, so you can install those by going pip isntall
git-pandas[examples]. Also added a requirements-dev.txt which installs
the requirements.txt, but also the optional extra dependencies, so you
can do things like run the examples.