### PR TITLE
Feature/branch lookup by commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 # Created by .ignore support plugin (hsz.mobi)
+
+# tests
+# these should be torn down after every test, but if a test is interupted,
+# they won't be until the next test
+tests/**/repos
+
 ### Python template
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # they won't be until the next test
 tests/**/repos
 
+# scratch stuff
+scratch
+
 ### Python template
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/examples/lifeline.py
+++ b/examples/lifeline.py
@@ -21,11 +21,11 @@ if __name__ == '__main__':
 
     # add in the file owner and whether or not each item is a refactor
     for idx, row in fch.iterrows():
-        fch.set_value(idx, 'file_owner', repo.file_owner(row.rev, row.filename))
+        fch.at(idx, 'file_owner', repo.file_owner(row.rev, row.filename))
         if abs(row.insertions - row.deletions) > threshold:
-            fch.set_value(idx, 'refactor', 1)
+            fch.at(idx, 'refactor', 1)
         else:
-            fch.set_value(idx, 'refactor', 0)
+            fch.at(idx, 'refactor', 0)
 
     # add in the time since column
     fch['time_until_refactor'] = 0
@@ -34,10 +34,10 @@ if __name__ == '__main__':
         chunk = fch[(fch['timestamp'] > row.timestamp) & (fch['refactor'] == 1) & (fch['filename'] == row.filename)]
         if chunk.shape[0] > 0:
             ts = chunk['timestamp'].min()
-            fch.set_value(idx, 'observed', True)
+            fch.at(idx, 'observed', True)
         else:
             ts = fch['timestamp'].max()
-        fch.set_value(idx, 'time_until_refactor', ts - row.timestamp)
+        fch.at(idx, 'time_until_refactor', ts - row.timestamp)
 
     # fch.to_csv('lifelines_data_t_%s.csv' % (threshold, ))
     # fch = pd.read_csv('lifelines_data_t_%s.csv' % (threshold, ))

--- a/examples/lifeline.py
+++ b/examples/lifeline.py
@@ -21,11 +21,11 @@ if __name__ == '__main__':
 
     # add in the file owner and whether or not each item is a refactor
     for idx, row in fch.iterrows():
-        fch.at(idx, 'file_owner', repo.file_owner(row.rev, row.filename))
+        fch.at[idx, 'file_owner'] = repo.file_owner(row.rev, row.filename)
         if abs(row.insertions - row.deletions) > threshold:
-            fch.at(idx, 'refactor', 1)
+            fch.at[idx, 'refactor'] = 1
         else:
-            fch.at(idx, 'refactor', 0)
+            fch.at[idx, 'refactor'] = 0
 
     # add in the time since column
     fch['time_until_refactor'] = 0
@@ -34,10 +34,10 @@ if __name__ == '__main__':
         chunk = fch[(fch['timestamp'] > row.timestamp) & (fch['refactor'] == 1) & (fch['filename'] == row.filename)]
         if chunk.shape[0] > 0:
             ts = chunk['timestamp'].min()
-            fch.at(idx, 'observed', True)
+            fch.at[idx, 'observed'] = True
         else:
             ts = fch['timestamp'].max()
-        fch.at(idx, 'time_until_refactor', ts - row.timestamp)
+        fch.at[idx, 'time_until_refactor'] = ts - row.timestamp
 
     # fch.to_csv('lifelines_data_t_%s.csv' % (threshold, ))
     # fch = pd.read_csv('lifelines_data_t_%s.csv' % (threshold, ))

--- a/gitpandas/project.py
+++ b/gitpandas/project.py
@@ -46,7 +46,9 @@ class ProjectDirectory(object):
     An object that refers to a directory full of git repositories, for bulk analysis.  It contains a collection of
     git-pandas repository objects, created by os.walk-ing a directory to file all child .git subdirectories.
 
-    :param working_dir: (optional, default=None), the working directory to search for repositories in, None for cwd, or an explicit list of directories containing git repositories
+    :param working_dir: (optional, default=None), the working directory to search for repositories in,
+        None for cwd, an explicit list of directories containing git repositories,
+        or a list of ``Repository`` instances
     :param ignore_repos: (optional, default=None), a list of directories to ignore when searching for git repos.
     :param verbose: (default=True), if True, will print out verbose logging to terminal
     :param verbose: optional, verbosity level of output, bool
@@ -62,7 +64,11 @@ class ProjectDirectory(object):
         else:
             self.repo_dirs = set([x[0].split('.git')[0] for x in os.walk(working_dir) if '.git' in x[0]])
 
-        self.repos = [Repository(r, verbose=verbose, tmp_dir=tmp_dir, cache_backend=cache_backend) for r in self.repo_dirs]
+        if all(isinstance(r, Repository) for r in self.repo_dirs):
+            self.repos = self.repo_dirs
+        else:
+            self.repos = [Repository(r, verbose=verbose, tmp_dir=tmp_dir, cache_backend=cache_backend)
+                          for r in self.repo_dirs]
 
         if ignore_repos is not None:
             self.repos = [x for x in self.repos if x.repo_name not in ignore_repos]

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -786,7 +786,24 @@ class Repository(object):
         """
 
         tags = self.repo.tags
-        df = DataFrame([x.name for x in list(tags)], columns=['tag'])
+        tags_meta = []
+        for tag in tags:
+            annotated = False
+            annotation = ""
+            if tag.tag:
+                tag_thyme = tag.tag.tagged_date
+                annotated = True
+                annotation = tag.tag.message
+            else:
+                tag_thyme = tag.commit.committed_date
+            commit_thyme = tag.commit.committed_date
+            tag_thyme = datetime.datetime.utcfromtimestamp(tag_thyme)
+            commit_thyme = datetime.datetime.utcfromtimestamp(commit_thyme)
+            tags_meta.append(
+                dict(tag=tag.name, tag_dt=tag_thyme, commit_dt=commit_thyme, annotated=annotated,
+                     annotation=annotation)
+            )
+        df = DataFrame(tags_meta)
         df['repository'] = self._repo_name()
 
         return df

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -659,7 +659,7 @@ class Repository(object):
             for y in committers:
                 try:
                     loc = blame.loc[y, 'loc']
-                    revs.set_value(idx, y, loc)
+                    revs.at(idx, y, loc)
                 except KeyError:
                     pass
 

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -610,10 +610,10 @@ class Repository(object):
                 skip = 1
 
             if df.shape[0] >= skip:
-                df = df.ix[range(0, df.shape[0], skip)]
+                df = df.iloc[range(0, df.shape[0], skip)]
                 df.reset_index()
             else:
-                df = df.ix[[0]]
+                df = df.iloc[[0]]
                 df.reset_index()
 
         return df
@@ -682,7 +682,7 @@ class Repository(object):
             if sum([row[x] for x in committers]) > 0:
                 keep_idx.append(idx)
 
-        revs = revs.ix[keep_idx]
+        revs = revs.loc[keep_idx]
 
         return revs
 
@@ -741,7 +741,7 @@ class Repository(object):
             if sum([row[x] for x in committers]) > 0:
                 keep_idx.append(idx)
 
-        revs = revs.ix[keep_idx]
+        revs = revs.iloc[keep_idx]
         revs.sort_index(ascending=False, inplace=True)
 
         return revs
@@ -865,7 +865,7 @@ class Repository(object):
         cumulative = 0
         tc = 0
         for idx in range(blame.shape[0]):
-            cumulative += blame.ix[idx, 'loc']
+            cumulative += blame.iloc[idx]["loc"]
             tc += 1
             if cumulative >= total / 2:
                 break

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -19,6 +19,7 @@ import fnmatch
 import shutil
 import warnings
 import numpy as np
+import pandas as pd
 from git import Repo, GitCommandError
 from gitpandas.cache import multicache, EphemeralCache, RedisDFCache
 from pandas import DataFrame, to_datetime
@@ -769,11 +770,13 @@ class Repository(object):
         data = [[x.name, True] for x in list(local_branches)]
 
         # then the remotes
-        remotes_branches = self.repo.git.branch('-r').replace(" ", "").split("->")[-1].splitlines()
-        for i, remote in enumerate(remotes_branches):
-            if remote.startswith("origin/"):
-                remotes_branches[i] = remote.lstrip("origin/")
-        remote_branches = set(remotes_branches)
+        remote_branches = self.repo.git.branch('-r').replace(" ", "").splitlines()
+        rb = []
+        for i, remote in enumerate(remote_branches):
+            if "->" in remote:
+                continue
+            rb.append(remote)
+        remote_branches = set(rb)
 
         data += [[x, False] for x in remote_branches]
 
@@ -794,50 +797,120 @@ class Repository(object):
 
         :returns: DataFrame
         """
-        branches = self.repo.git.branch('--contains', commit).replace(" ", "").lstrip("*").splitlines()
+        branches = self.repo.git.branch('-a', '--contains', commit).replace(" ", "").lstrip("*").splitlines()
         df = DataFrame(branches, columns=["branch"])
         df["commit"] = str(commit)
         df['repository'] = self._repo_name()
 
         return df
 
-    def commits_in_tag(self, commit, days=180):
+    def commits_in_tags(self, start=np.timedelta64(6, "M"), end=None):
+        """
+        Analyze each tag, and trace backwards from the tag to all commits that make
+        up that tag. This method looks at the commit for the tag, and then works
+        backwards to that commits parents, and so on and so, until it hits another
+        tag, is out of the time range, or hits the root commit. It returns a DataFrame
+        with the branches:
+
+         * tag_date (index)
+         * commit_date (index)
+         * commit_sha
+         * tag
+         * repository
+
+        :param start: (optional, defaults to 6 months before today) the start time for commits,
+            can be a pd.Timestamp, or a np.timedelta or pd.Timedelta
+            (which then calculates from today)
+        :type start: pd.Timestamp | np.timedelta | pd.Timedelta
+        :param end: (optional, defaults to None) the end time for commits,
+            can be a pd.Timestamp, or a np.timedelta or pd.Timedelta
+            (which then calculates from today)
+        :type end: pd.Timestamp | np.timedelta | pd.Timedelta
+        """
+
+        # If we pass in a timedelta instead of a timestamp, calc the timestamp relative to now
+        if isinstance(start, pd.Timedelta) or isinstance(start, np.timedelta64):
+            start = pd.Timestamp.today(tz="UTC") - start
+        if isinstance(end, pd.Timedelta) or isinstance(end, np.timedelta64):
+            end = pd.Timestamp.today(tz="UTC") - end
+
+        # remove tagged commits outside our date ranges
         df_tags = self.tags()
-        commits = [self._commits_per_tag_helper(commit, df_tags)]
-        if days:
-            dlim = time.time() - days * 24 * 3600
-        else:
-            dlim = None
-        self._commits_per_tag_recursive(commit=commit, df_tags=df_tags, commits=commits, dlim=dlim)
-        df = DataFrame(commits)
-        df["commit_date"] = to_datetime(df['commit_date'], unit="s").dt.tz_localize("UTC")
+        if start:
+            df_tags = df_tags.query(f'commit_date > "{start}"').copy()
+        if end:
+            df_tags = df_tags.query(f'commit_date < "{end}"').copy()
+
+        # convert to unix time to speed up calculations later
+        start = (start - pd.Timestamp("1970-01-01", tz="UTC")) // pd.Timedelta('1s') if start else start
+        end = (end - pd.Timestamp("1970-01-01", tz="UTC")) // pd.Timedelta('1s') if end else end
+
+        ds = []
+        checked_commits = set()
+
+        df_tags["filled_shas"] = df_tags["tag_sha"].fillna(value=df_tags["commit_sha"])
+        for sha, tag in df_tags[["filled_shas", "tag"]].sort_index(level="tag_date").values:
+            commit = self.repo.commit(sha)
+            before_start = start and commit.committed_date < start
+            passed_end = end and commit.committed_date > end
+            already_checked = str(commit) in checked_commits
+            if before_start or passed_end or already_checked:
+                continue
+            tag = self.repo.tag(tag)
+
+            checked_commits.add(str(commit))
+            ds.append(self._commits_per_tags_helper(commit, df_tags, tag=tag)[0])
+
+        for sha, tag in df_tags[["filled_shas", "tag"]].sort_index(level="tag_date").values:
+            commit = self.repo.commit(sha)
+            tag = self.repo.tag(tag)
+            self._commits_per_tags_recursive(commit=commit, df_tags=df_tags, ds=ds, start=start, end=end,
+                                             checked_commits=checked_commits, tag=tag)
+        df = pd.DataFrame(ds)
         df['repository'] = self._repo_name()
+
+        df = df.sort_values(by=["tag", "commit_date"])
+        df = df.set_index(keys=['tag_date', 'commit_date'], drop=True)
 
         return df
 
-    def _commits_per_tag_recursive(self, commit, df_tags, commits=None, tag=None, checked_commits=None, dlim=None):
-        commits = commits if commits is not None else []
+    def _commits_per_tags_recursive(self, commit, df_tags, ds=None, tag=None, checked_commits=None, start=None,
+                                    end=None):
+        ds = ds if ds is not None else []
         checked_commits = checked_commits if checked_commits is not None else set()
 
         for commit in commit.parents:
-            if dlim and commit.committed_date < dlim:
-                break
-            if str(commit) in checked_commits:
+            before_start = start and commit.committed_date < start
+            passed_end = end and commit.committed_date > end
+            already_checked = str(commit) in checked_commits
+            if before_start or passed_end or already_checked:
                 continue
-            else:
-                checked_commits.add(str(commit))
-            commit_meta = self._commits_per_tag_helper(commit=commit, df_tags=df_tags, tag=tag)
-            tag = commit_meta["tag"]
-            commits.append(commit_meta)
-            self._commits_per_tag_recursive(commit=commit, df_tags=df_tags, commits=commits, tag=tag, checked_commits=checked_commits, dlim=dlim)
+            checked_commits.add(str(commit))
+            commit_meta, tag = self._commits_per_tags_helper(commit=commit, df_tags=df_tags, tag=tag)
+            ds.append(commit_meta)
+            self._commits_per_tags_recursive(commit=commit, df_tags=df_tags, ds=ds, tag=tag,
+                                             checked_commits=checked_commits, start=start, end=end)
 
-    def _commits_per_tag_helper(self, commit, df_tags, tag=None):
-        tag_pd = df_tags.loc[df_tags.commit_sha.str.contains(str(commit))].tag
+    def _commits_per_tags_helper(self, commit, df_tags, tag=None):
+        tag_pd = (df_tags
+                  .loc[
+                      (df_tags["commit_sha"].str.contains(str(commit)))
+                      | (df_tags["tag_sha"].str.contains(str(commit)))
+                  ].tag)
         if not tag_pd.empty:
-            tag = tag_pd[0]
-        branches = self.get_branches_by_commit(commit)["branch"].to_numpy()
+            tag = self.repo.tag(tag_pd[0])
+        if tag and tag.tag:
+            tag_date = tag.tag.tagged_date
+        elif tag:
+            tag_date = tag.commit.committed_date
+        else:
+            tag_date = None
 
-        return dict(commit_sha=str(commit), tag=tag, commit_date=commit.committed_date, branches=branches)
+        return (dict(commit_sha=str(commit),
+                     tag=str(tag),
+                     tag_date=pd.to_datetime(tag_date, unit="s", utc=True),
+                     commit_date=pd.to_datetime(commit.committed_date, unit="s", utc=True)),
+                tag)
 
     def tags(self):
         """
@@ -871,6 +944,7 @@ class Repository(object):
             d["commit_date"] = tag.commit.committed_date
             d["tag"] = tag.name
             d["commit_sha"] = tag.commit.hexsha
+
             tags_meta.append(d)
         df = DataFrame(tags_meta, columns=cols)
 
@@ -879,6 +953,7 @@ class Repository(object):
         df['repository'] = self._repo_name()
 
         df = df.set_index(keys=['tag_date', 'commit_date'], drop=True)
+        df = df.sort_index(level=["tag_date", "commit_date"])
 
         return df
 

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -659,7 +659,7 @@ class Repository(object):
             for y in committers:
                 try:
                     loc = blame.loc[y, 'loc']
-                    revs.at(idx, y, loc)
+                    revs.at[idx, y] = loc
                 except KeyError:
                     pass
 

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -879,7 +879,7 @@ class Repository(object):
             tag = self.repo.tag(tag)
             self._commits_per_tags_recursive(commit=commit, df_tags=df_tags, ds=ds, start=start, end=end,
                                              checked_commits=checked_commits, tag=tag)
-        df = pd.DataFrame(ds)
+        df = pd.DataFrame(ds, columns=["tag_date", "commit_date", "commit_sha", "tag"])
         df = self._add_labels_to_df(df)
 
         df = df.sort_values(by=["tag", "commit_date"])

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -310,7 +310,7 @@ class Repository(object):
                        columns=['author', 'committer', 'date', 'message', 'lines', 'insertions', 'deletions', 'net'])
 
         # format the date col and make it the index
-        df['date'] = to_datetime(df['date'].map(datetime.datetime.fromtimestamp))
+        df['date'] = to_datetime(df['date'], unit="s").dt.tz_localize("UTC")
         df.set_index(keys=['date'], drop=True, inplace=True)
 
         return df
@@ -392,7 +392,7 @@ class Repository(object):
                        columns=['author', 'committer', 'date', 'message', 'rev', 'filename', 'insertions', 'deletions'])
 
         # format the date col and make it the index
-        df['date'] = to_datetime(df['date'].map(datetime.datetime.fromtimestamp))
+        df['date'] = to_datetime(df['date'], unit="s").dt.tz_localize("UTC")
         df.set_index(keys=['date'], drop=True, inplace=True)
 
         return df
@@ -665,7 +665,7 @@ class Repository(object):
 
         del revs['rev']
 
-        revs['date'] = to_datetime(revs['date'].map(datetime.datetime.fromtimestamp))
+        revs['date'] = to_datetime(revs['date'], unit="s").dt.tz_localize("UTC")
         revs.set_index(keys=['date'], drop=True, inplace=True)
         revs = revs.fillna(0.0)
 
@@ -724,7 +724,7 @@ class Repository(object):
         revs = DataFrame(ds)
         del revs['rev']
 
-        revs['date'] = to_datetime(revs['date'].map(datetime.datetime.fromtimestamp))
+        revs['date'] = to_datetime(revs['date'], unit="s").dt.tz_localize("UTC")
         revs.set_index(keys=['date'], drop=True, inplace=True)
         revs = revs.fillna(0.0)
 
@@ -797,13 +797,13 @@ class Repository(object):
             else:
                 tag_thyme = tag.commit.committed_date
             commit_thyme = tag.commit.committed_date
-            tag_thyme = datetime.datetime.utcfromtimestamp(tag_thyme)
-            commit_thyme = datetime.datetime.utcfromtimestamp(commit_thyme)
             tags_meta.append(
                 dict(tag=tag.name, tag_dt=tag_thyme, commit_dt=commit_thyme, annotated=annotated,
                      annotation=annotation)
             )
         df = DataFrame(tags_meta)
+        df['tag_dt'] = to_datetime(df['tag_dt'], unit="s").dt.tz_localize("UTC")
+        df['commit_dt'] = to_datetime(df['commit_dt'], unit="s").dt.tz_localize("UTC")
         df['repository'] = self._repo_name()
 
         return df
@@ -953,7 +953,7 @@ class Repository(object):
 
         # add in last edit date for the file
         df['last_edit_date'] = df['file'].map(self._file_last_edit)
-        df['last_edit_date'] = to_datetime(df['last_edit_date'])
+        df['last_edit_date'] = to_datetime(df['last_edit_date']).dt.tz_localize("UTC")
 
         df = df.set_index('file')
 

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -826,6 +826,8 @@ class Repository(object):
             can be a pd.Timestamp, or a np.timedelta or pd.Timedelta
             (which then calculates from today)
         :type end: pd.Timestamp | np.timedelta | pd.Timedelta
+
+        :returns: DataFrame
         """
 
         # If we pass in a timedelta instead of a timestamp, calc the timestamp relative to now

--- a/tests/test_Project/test_properties.py
+++ b/tests/test_Project/test_properties.py
@@ -124,10 +124,10 @@ class TestLocalProperties(unittest.TestCase):
         self.assertIn('master', branches)
 
     def test_tags(self):
-        tags = list(self.projectd_1.tags()['tag'].values)
+        tags = self.projectd_1.tags()
         self.assertEqual(len(tags), 0)
 
-        tags = list(self.projectd_2.tags()['tag'].values)
+        tags = self.projectd_2.tags()
         self.assertEqual(len(tags), 0)
 
     def test_is_bare(self):

--- a/tests/test_Repository/test_properties.py
+++ b/tests/test_Repository/test_properties.py
@@ -94,7 +94,7 @@ class TestLocalProperties(unittest.TestCase):
         self.assertIn('master', branches)
 
     def test_tags(self):
-        tags = list(self.repo.tags()['tag'].values)
+        tags = self.repo.tags()
         self.assertEqual(len(tags), 0)
 
     def test_is_bare(self):


### PR DESCRIPTION
# Summary

* Add method ``commits_in_tags``, that analyzes all commits that make it into a tag.
  * """Analyze each tag, and trace backwards from the tag to all commits that make
        up that tag. This method looks at the commit for the tag, and then works
        backwards to that commits parents, and so on and so, until it hits another
        tag, is out of the time range, or hits the root commit. It returns a DataFrame
        with the branches"""
* Add ability for ``ProjectDirectory`` to take a list of ``Repository`` instances directly.
* Add repository parameter ``labels_to_add``, which are extra labels to add to outputted DataFrames in addition to repo names. Which can be useful especially for ``ProjectDirectory``, where you have several repos that fall under similar categories, so you can group them together.