### PR TITLE
Test the supported Python range in CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
     
     steps:
     - name: Checkout code
@@ -22,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: ${{ matrix.python-version }}
     
     - name: Install uv
       run: |
@@ -36,7 +39,7 @@ jobs:
     
     - name: Install dependencies
       run: |
-        uv pip install --system -e ".[dev,datasets]"
+        uv pip install --system -e ".[dev]"
     
     - name: Configure Git
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "git-pandas"
 version = "2.5.0"
 description = "A utility for interacting with data from git repositories as Pandas dataframes"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {text = "BSD"}
 authors = [
     {name = "Will McGinnis", email = "will@mcginniscommawill.com"},
@@ -22,7 +22,7 @@ keywords = ["git", "pandas", "data", "analysis"]
 dependencies = [
     "gitpython>=1.0.0",
     "numpy>=1.9.0",
-    "pandas>=2.0.0",
+    "pandas>=2.0.0,<3.0.0",
     "requests",
     "redis",
     "coverage>=5.0.0",
@@ -95,4 +95,4 @@ suppress-none-returning = true
 quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
-line-ending = "auto" 
+line-ending = "auto"


### PR DESCRIPTION
Closes #30

## Summary
- remove the undefined `datasets` extra from the CI dependency install
- run the test job on Python 3.10 through 3.12
- raise the declared minimum to Python 3.10 because the package uses PEP 604 union syntax that cannot import on 3.8 or 3.9
- constrain pandas to the compatible 2.x line after the expanded matrix exposed pandas 3 API breakage

## Verification
- `git diff --check` — passed
- parsed `.github/workflows/test-suite.yml` with PyYAML — passed
- `uv run --extra dev ruff check .` — passed
- `MPLBACKEND=Agg uv run --extra dev pytest -q -m "not slow"` — passed: 328 passed, 1 deselected
- `uv build` — passed; built the sdist and wheel
- GitHub Actions — docs and Python 3.10, 3.11, and 3.12 test jobs all passed