### PR TITLE
Guard Project.blame()/file_detail() against AttributeError when all repos fail

### DIFF
--- a/gitpandas/project.py
+++ b/gitpandas/project.py
@@ -385,8 +385,6 @@ class ProjectDirectory:
                 # Use logger instead of print
                 logger.warning(f"Repo: {repo} seems to not have the branch: {branch}")
 
-        df.reset_index()
-
         if by == "committer" or by == "author":
             df = df.groupby(com).agg({"hours": sum})
             df = df.reset_index()
@@ -631,11 +629,18 @@ class ProjectDirectory:
                 logger.warning(f"Repo: {repo} couldnt be blamed")
                 pass
 
+        groupby_column = "committer" if committer else "author"
+
+        if df is None:
+            # No repos, or every repo raised GitCommandError — return an empty
+            # DataFrame matching the normal output shape.
+            columns = [groupby_column, "file", "loc"] if by == "file" else [groupby_column, "loc"]
+            return pd.DataFrame(columns=columns)
+
         # Reset index to convert committer/author from index to column
         df = df.reset_index()
 
         # Fix column naming after reset_index - the grouped column becomes 'index'
-        groupby_column = "committer" if committer else "author"
         if "index" in df.columns and groupby_column not in df.columns:
             df = df.rename(columns={"index": groupby_column})
         elif groupby_column not in df.columns:
@@ -714,6 +719,12 @@ class ProjectDirectory:
             except GitCommandError:
                 # Use logger instead of print
                 logger.warning(f"Repo: {repo} couldnt be inspected")
+
+        if df is None:
+            # No repos, or every repo raised GitCommandError — return an empty
+            # DataFrame with the same (file, repository) index as the normal output.
+            empty = pd.DataFrame(columns=["file", "repository", "loc", "file_owner", "ext", "last_edit_date"])
+            return empty.set_index(["file", "repository"])
 
         df = df.reset_index()
         df = df.set_index(["file", "repository"])
@@ -1096,7 +1107,6 @@ class ProjectDirectory:
                     # Use logger instead of print
                     logger.warning(f"Repo: {repo} couldn't be inspected")
 
-            df.reset_index()
             logger.info(f"Calculated bus factor for {len(df)} repositories.")
             return df
 
@@ -1151,8 +1161,6 @@ class ProjectDirectory:
             except GitCommandError:
                 # Use logger instead of print
                 logger.warning(f"Repo: {repo} couldn't be inspected")
-
-        df.reset_index()
 
         aggs = ["hour_of_day", "day_of_week"]
         if by is not None:

--- a/tests/test_Project/test_blame_file_detail_empty.py
+++ b/tests/test_Project/test_blame_file_detail_empty.py
@@ -1,0 +1,100 @@
+"""Regression tests for ProjectDirectory.blame/file_detail when every repo fails.
+
+These methods initialize their accumulator to None and populate it only inside a
+try/except GitCommandError. Before the guard was added, an all-repos-fail (or
+empty project) run left the accumulator as None and crashed with
+``AttributeError: 'NoneType' object has no attribute 'reset_index'``. Each method
+should instead return a well-formed empty DataFrame.
+"""
+
+from contextlib import ExitStack, contextmanager
+from unittest.mock import patch
+
+import git
+import pandas as pd
+import pytest
+from git import GitCommandError
+
+from gitpandas import ProjectDirectory
+
+
+@contextmanager
+def patch_all(repos, method, exc):
+    """Patch the same method on every repo to raise the given exception."""
+    with ExitStack() as stack:
+        for repo in repos:
+            stack.enter_context(patch.object(repo, method, side_effect=exc))
+        yield
+
+
+class TestBlameFileDetailAllReposFail:
+    @pytest.fixture
+    def temp_repos(self, tmp_path):
+        """Create two temporary git repositories with an initial commit each."""
+        repos = []
+        for i in range(2):
+            repo_path = tmp_path / f"test_repo_{i}"
+            repo_path.mkdir()
+            repo = git.Repo.init(repo_path)
+            repo.config_writer().set_value("user", "name", "Test User").release()
+            repo.config_writer().set_value("user", "email", "test@example.com").release()
+            (repo_path / "README.md").write_text(f"# Test Repository {i}")
+            repo.index.add(["README.md"])
+            repo.index.commit(f"Initial commit for repo {i}")
+            repos.append(str(repo_path))
+        return repos
+
+    def test_blame_all_repos_fail(self, temp_repos):
+        """blame() returns an empty DataFrame when every repo raises GitCommandError."""
+        project = ProjectDirectory(working_dir=temp_repos)
+
+        with patch_all(project.repos, "blame", GitCommandError("blame failed", 128)):
+            blame_df = project.blame()
+
+        assert isinstance(blame_df, pd.DataFrame)
+        assert blame_df.empty
+        assert list(blame_df.columns) == ["committer", "loc"]
+
+    def test_blame_by_file_all_repos_fail(self, temp_repos):
+        """blame(by='file') returns an empty DataFrame with the file column."""
+        project = ProjectDirectory(working_dir=temp_repos)
+
+        with patch_all(project.repos, "blame", GitCommandError("blame failed", 128)):
+            blame_df = project.blame(by="file")
+
+        assert isinstance(blame_df, pd.DataFrame)
+        assert blame_df.empty
+        assert list(blame_df.columns) == ["committer", "file", "loc"]
+
+    def test_file_detail_all_repos_fail(self, temp_repos):
+        """file_detail() returns an empty DataFrame when every repo raises GitCommandError."""
+        project = ProjectDirectory(working_dir=temp_repos)
+
+        with patch_all(project.repos, "file_detail", GitCommandError("file_detail failed", 128)):
+            detail_df = project.file_detail()
+
+        assert isinstance(detail_df, pd.DataFrame)
+        assert detail_df.empty
+        assert list(detail_df.index.names) == ["file", "repository"]
+
+
+class TestBlameFileDetailEmptyProject:
+    def test_blame_empty_project(self):
+        """blame() on a project with no repos returns an empty DataFrame."""
+        project = ProjectDirectory(working_dir=[])
+        assert len(project.repos) == 0
+
+        blame_df = project.blame()
+        assert isinstance(blame_df, pd.DataFrame)
+        assert blame_df.empty
+        assert list(blame_df.columns) == ["committer", "loc"]
+
+    def test_file_detail_empty_project(self):
+        """file_detail() on a project with no repos returns an empty DataFrame."""
+        project = ProjectDirectory(working_dir=[])
+        assert len(project.repos) == 0
+
+        detail_df = project.file_detail()
+        assert isinstance(detail_df, pd.DataFrame)
+        assert detail_df.empty
+        assert list(detail_df.index.names) == ["file", "repository"]


### PR DESCRIPTION
Closes #29

## What changed
Two `ProjectDirectory` aggregation methods initialized their accumulator to `None`, populated it only inside a `try/except GitCommandError`, then called `df.reset_index()` unconditionally. When **every** repo raised `GitCommandError` (empty/no-commit repos, a bad branch) — or `self.repos` was empty — `df` stayed `None` and the method crashed with `AttributeError: 'NoneType' object has no attribute 'reset_index'` instead of returning an empty DataFrame.

- **`blame`** — added an `if df is None` guard returning an empty DataFrame with `[committer/author, loc]` columns (plus `file` for `by='file'`), matching the method's normal output shape and the existing empty-return already in the method.
- **`file_detail`** — added an `if df is None` guard returning an empty DataFrame indexed by `(file, repository)`, matching its normal output.

This mirrors the guard sibling methods like `file_change_history` already use.

Separately, removed three no-op `df.reset_index()` calls whose result was discarded (default `inplace=False`, no reassignment): `hours_estimate`, `bus_factor` (`by='repository'`), and `punchcard`. The index is already the default RangeIndex at each of those points, so output is unchanged.

## Tests
Added `tests/test_Project/test_blame_file_detail_empty.py` covering the all-repos-fail and empty-project paths for both `blame` and `file_detail`. Verified they fail before the fix (`AttributeError`) and pass after.

## Verification
- `MPLBACKEND=Agg uv run --extra dev pytest tests/test_Project/test_blame_file_detail_empty.py -q` → **5 passed**.
- Confirmed the new tests fail on the pre-fix tree (`AttributeError: 'NoneType' object has no attribute 'reset_index'`).
- `MPLBACKEND=Agg uv run --extra dev pytest -m "not slow"` → 326 passed, 7 failed. The 7 failures are pre-existing and unrelated to this change (pandas-3 `StringArray`/dtype issues in commit-history dtypes and lifeline plots); they reproduce on `master` without this diff.
- `uv run --extra dev ruff check .` → **All checks passed!**