### PR TITLE
Fix multi-repository blame aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Unreleased
 
 ## Bug Fixes
 
+### Project Blame Aggregation
+ * **FIXED**: `ProjectDirectory.blame()` now preserves committer/author and file grouping keys when combining multiple repositories. Contributors are aggregated by name across repositories, `blame(by="file")` no longer raises `KeyError`, and project-level bus factors are calculated from contributors instead of row numbers.
+
 ### Cache Correctness
  * **FIXED**: `@multicache` built cache keys from `kwargs` only, so any argument passed *positionally* was invisible to the key and collapsed to `None`. Keys are now resolved against the decorated method's signature (`inspect.signature().bind()` + `apply_defaults()`), so positional and keyword calls key identically. This fixes:
    - `Repository(working_dir=<master-only repo>, cache_backend=...)` raising `ValueError: Could not detect default branch` — the internal `has_branch("main")` / `has_branch("master")` probes shared one key.

--- a/gitpandas/project.py
+++ b/gitpandas/project.py
@@ -608,22 +608,15 @@ class ProjectDirectory:
 
         for repo in self.repos:
             try:
-                if df is None:
-                    df = repo.blame(
-                        committer=committer,
-                        by=by,
-                        ignore_globs=ignore_globs,
-                        include_globs=include_globs,
-                    )
-                else:
-                    blame_df = repo.blame(
-                        committer=committer,
-                        by=by,
-                        ignore_globs=ignore_globs,
-                        include_globs=include_globs,
-                    )
-                    if not blame_df.empty:
-                        df = pd.concat([df, blame_df], ignore_index=True)
+                blame_df = repo.blame(
+                    committer=committer,
+                    by=by,
+                    ignore_globs=ignore_globs,
+                    include_globs=include_globs,
+                )
+                if not blame_df.empty:
+                    blame_df = blame_df.reset_index()
+                    df = blame_df if df is None else pd.concat([df, blame_df], ignore_index=True)
             except GitCommandError:
                 # Use logger instead of print
                 logger.warning(f"Repo: {repo} couldnt be blamed")
@@ -637,18 +630,13 @@ class ProjectDirectory:
             columns = [groupby_column, "file", "loc"] if by == "file" else [groupby_column, "loc"]
             return pd.DataFrame(columns=columns)
 
-        # Reset index to convert committer/author from index to column
-        df = df.reset_index()
-
-        # Fix column naming after reset_index - the grouped column becomes 'index'
-        if "index" in df.columns and groupby_column not in df.columns:
-            df = df.rename(columns={"index": groupby_column})
-        elif groupby_column not in df.columns:
+        if groupby_column not in df.columns:
             logger.warning(
                 f"Expected column '{groupby_column}' not found in blame data. Available columns: {df.columns.tolist()}"
             )
             # Return empty DataFrame with proper structure if column is missing
-            return pd.DataFrame(columns=[groupby_column, "loc"])
+            columns = [groupby_column, "file", "loc"] if by == "file" else [groupby_column, "loc"]
+            return pd.DataFrame(columns=columns)
 
         if committer:
             if by == "repository":

--- a/tests/test_Project/test_blame_multi_repo.py
+++ b/tests/test_Project/test_blame_multi_repo.py
@@ -1,0 +1,55 @@
+import git
+import pytest
+
+from gitpandas import ProjectDirectory
+
+
+@pytest.fixture
+def single_author_project(tmp_path, default_branch):
+    repos_dir = tmp_path / "repos"
+    repos_dir.mkdir()
+
+    for repo_number in range(3):
+        repo_dir = repos_dir / f"repo{repo_number}"
+        repo_dir.mkdir()
+        repo = git.Repo.init(repo_dir)
+        repo.git.config("user.name", "Alice")
+        repo.git.config("user.email", "alice@example.com")
+        file_name = f"file{repo_number}.py"
+        (repo_dir / file_name).write_text("first\nsecond\nthird\n")
+        repo.git.add(file_name)
+        repo.git.commit(m=f"add {file_name}")
+
+    return ProjectDirectory(working_dir=str(repos_dir), default_branch=default_branch)
+
+
+def test_blame_aggregates_committer_across_repositories(single_author_project):
+    blame = single_author_project.blame()
+
+    assert blame.index.tolist() == ["Alice"]
+    assert blame.index.name == "committer"
+    assert blame.loc["Alice", "loc"] == 9
+
+
+def test_blame_by_file_preserves_committer_and_file(single_author_project):
+    blame = single_author_project.blame(by="file")
+
+    assert blame.index.names == ["committer", "file"]
+    assert blame["loc"].to_dict() == {
+        ("Alice", "file0.py"): 3,
+        ("Alice", "file1.py"): 3,
+        ("Alice", "file2.py"): 3,
+    }
+
+
+def test_project_bus_factor_uses_aggregated_committers(single_author_project):
+    bus_factor = single_author_project.bus_factor(by="projectd")
+
+    assert bus_factor.loc[0, "bus factor"] == 1
+
+
+def test_project_blame_loc_matches_repository_totals(single_author_project):
+    project_total = single_author_project.blame()["loc"].sum()
+    repository_total = sum(repo.blame()["loc"].sum() for repo in single_author_project.repos)
+
+    assert project_total == repository_total == 9


### PR DESCRIPTION
Closes #36

## Summary

- preserve committer/author and file grouping keys by resetting each repository blame index before concatenation
- aggregate the same contributor across repositories and restore file-level project blame
- return the promised file-aware empty shape when file grouping keys are unavailable
- add multi-repository regressions for contributor names and LOC, file grouping, project bus factor, and per-repository LOC totals
- document the corrected behavior in the changelog

## Verification

- `MPLBACKEND=Agg uv run pytest -m "not slow"` — 348 passed, 1 deselected
- `uv run ruff check .` — all checks passed
- targeted existing single-repository and empty-project tests — 25 passed
- branch-point proof with only the new tests present — 3 failed as expected (numeric committer indexes, `KeyError: file`, and bus factor 2); the LOC-total cross-check passed because index loss does not alter total LOC
- mutation proof using `reset_index(drop=True)` — all 4 new tests failed; restored the implementation afterward