### PR TITLE
Preserve cached method signatures for reflection

### DIFF
--- a/gitpandas/cache.py
+++ b/gitpandas/cache.py
@@ -5,6 +5,7 @@ import os
 import pickle
 import threading
 from datetime import datetime, timezone
+from functools import wraps
 
 try:
     import redis
@@ -77,6 +78,7 @@ def multicache(key_prefix, key_list, skip_if=None):
                     f"{func.__qualname__}: {unknown}. Valid parameters: {sorted(signature.parameters)}"
                 )
 
+        @wraps(func)
         def deco(self, *args, **kwargs):
             # If no cache backend, just run the function
             if self.cache_backend is None:

--- a/tests/test_cached_signatures.py
+++ b/tests/test_cached_signatures.py
@@ -1,0 +1,66 @@
+import importlib.util
+import inspect
+import sys
+import types
+from pathlib import Path
+
+from gitpandas import Repository
+
+
+def test_cached_repository_methods_preserve_signatures():
+    assert inspect.signature(Repository.commit_history) == inspect.Signature(
+        parameters=[
+            inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+            inspect.Parameter("branch", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None),
+            inspect.Parameter("limit", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None),
+            inspect.Parameter("days", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None),
+            inspect.Parameter("ignore_globs", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None),
+            inspect.Parameter("include_globs", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None),
+        ]
+    )
+    assert list(inspect.signature(Repository.blame).parameters) == [
+        "self",
+        "rev",
+        "committer",
+        "by",
+        "ignore_globs",
+        "include_globs",
+    ]
+    assert inspect.signature(Repository.blame).parameters["rev"].default == "HEAD"
+
+
+def test_mcp_wrapper_preserves_cached_method_signature(monkeypatch):
+    class FastMCPStub:
+        def __init__(self, _name):
+            pass
+
+        def tool(self):
+            return lambda func: func
+
+    mcp_module = types.ModuleType("mcp")
+    mcp_server_module = types.ModuleType("mcp.server")
+    fastmcp_module = types.ModuleType("mcp.server.fastmcp")
+    fastmcp_module.FastMCP = FastMCPStub
+    monkeypatch.setitem(sys.modules, "mcp", mcp_module)
+    monkeypatch.setitem(sys.modules, "mcp.server", mcp_server_module)
+    monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", fastmcp_module)
+
+    server_path = Path(__file__).parents[1] / "mcp_server" / "server.py"
+    spec = importlib.util.spec_from_file_location("gitpandas_mcp_server", server_path)
+    server = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(server)
+
+    wrapper = server.create_repo_tool_wrapper("commit_history", Repository.commit_history)
+
+    signature = inspect.signature(wrapper)
+    assert list(signature.parameters) == [
+        "repo_name",
+        "branch",
+        "limit",
+        "days",
+        "ignore_globs",
+        "include_globs",
+    ]
+    assert signature.parameters["repo_name"].annotation is str
+    assert all(parameter.kind is not inspect.Parameter.VAR_POSITIONAL for parameter in signature.parameters.values())
+    assert all(parameter.kind is not inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values())


### PR DESCRIPTION
Closes #40

## Summary
- preserve cached Repository method metadata and signatures with `functools.wraps`
- cover direct Repository introspection for representative cached methods
- verify generated MCP wrappers expose `repo_name` plus original named parameters and defaults without synthetic variadic parameters

## Verification
- `MPLBACKEND=Agg uv run pytest -m "not slow"` — 350 passed, 1 deselected
- `uv run ruff check .` — passed
- mutation check: temporarily removed `@wraps(func)` and ran `uv run pytest tests/test_cached_signatures.py` — both signature tests failed as intended; restored the decorator and reran the full gate