### PR TITLE
Fix warm cache key consistency

### DIFF
--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -314,10 +314,9 @@ class Repository:
         :param include_globs: (optinal, default=None) a list of globs to include, default of None includes everything.
         :return: DataFrame
         """
-        if branch is None:
-            branch = self.default_branch
+        resolved_branch = self.default_branch if branch is None else branch
 
-        logger.info(f"Starting hours estimation for branch '{branch}'")
+        logger.info(f"Starting hours estimation for branch '{resolved_branch}'")
 
         max_diff_in_minutes = grouping_window * 60.0
         first_commit_addition_in_minutes = single_commit_hours * 60.0
@@ -1327,11 +1326,10 @@ class Repository:
             If both ignore_globs and include_globs are provided, files must match an include
             pattern and not match any ignore patterns to be included.
         """
-        if branch is None:
-            branch = self.default_branch
+        resolved_branch = self.default_branch if branch is None else branch
 
         logger.info(
-            f"Starting cumulative blame calculation for branch '{branch}'. "
+            f"Starting cumulative blame calculation for branch '{resolved_branch}'. "
             f"Limit: {limit}, Skip: {skip}, Num Datapoints: {num_datapoints}, "
             f"Committer: {committer}, Skip Broken: {skip_broken}"
         )
@@ -1349,7 +1347,7 @@ class Repository:
         logger.debug("Fetching all committers to pre-populate columns...")
         committers = set()
         try:
-            for commit in self.repo.iter_commits(branch):
+            for commit in self.repo.iter_commits(resolved_branch):
                 try:
                     # Determine the name based on the 'committer' flag
                     name = commit.committer.name if committer else commit.author.name
@@ -1459,7 +1457,7 @@ class Repository:
             logger.error(f"Error processing cumulative blame data: {e}")
             return pd.DataFrame(index=pd.to_datetime([]).tz_localize("UTC"))
 
-        logger.info(f"Finished cumulative blame calculation for '{branch}'. Result shape: {revs.shape}")
+        logger.info(f"Finished cumulative blame calculation for '{resolved_branch}'. Result shape: {revs.shape}")
         return revs
 
     @multicache(
@@ -1508,11 +1506,10 @@ class Repository:
         Returns:
             DataFrame: DataFrame with blame information
         """
-        if branch is None:
-            branch = self.default_branch
+        resolved_branch = self.default_branch if branch is None else branch
 
         logger.info(
-            f"Starting parallel cumulative blame for branch '{branch}'. "
+            f"Starting parallel cumulative blame for branch '{resolved_branch}'. "
             f"Limit: {limit}, Skip: {skip}, Num Datapoints: {num_datapoints}, "
             f"Committer: {committer}, Workers: {workers}, Skip Broken: {skip_broken}"
         )
@@ -1526,7 +1523,7 @@ class Repository:
 
         # If revs is empty, return an empty DataFrame with proper index
         if revs.empty:
-            logger.warning(f"No valid revisions found for branch '{branch}'. Returning empty DataFrame.")
+            logger.warning(f"No valid revisions found for branch '{resolved_branch}'. Returning empty DataFrame.")
             return pd.DataFrame(index=pd.to_datetime([]).tz_localize("UTC"))
 
         logger.debug(f"Prepared {len(revs)} revisions for parallel processing.")
@@ -2399,9 +2396,6 @@ class Repository:
             f"Ignore: {ignore_globs}, Include: {include_globs}"
         )
 
-        if branch is None:
-            branch = self.default_branch
-
         logger.debug("Fetching commit history for punchcard...")
         ch = self.commit_history(
             branch=branch,
@@ -2429,7 +2423,8 @@ class Repository:
             for col in ["lines", "insertions", "deletions", "net"]:
                 punch_card[col] = (punch_card[col] / punch_card[col].sum()) * normalize
 
-        logger.info(f"Finished generating punchcard data for '{branch}'. Result shape: {punch_card.shape}")
+        resolved_branch = self.default_branch if branch is None else branch
+        logger.info(f"Finished generating punchcard data for '{resolved_branch}'. Result shape: {punch_card.shape}")
         return punch_card
 
     @multicache(key_prefix="has_branch", key_list=["branch"])
@@ -2883,7 +2878,7 @@ class Repository:
                 - 'file_detail': Load file details
                 - 'list_files': Load file listing
                 - 'file_change_rates': Load file change statistics
-            **kwargs: Additional keyword arguments to pass to the methods.
+            **kwargs: Additional keyword arguments to pass to compatible methods unchanged.
                 Common arguments include:
                 - branch: Branch to analyze (default: repository's default branch)
                 - limit: Limit number of commits to analyze
@@ -2950,12 +2945,7 @@ class Repository:
                 # Handle special cases for method arguments
                 method_kwargs = kwargs.copy()
 
-                # For methods that might need specific arguments
-                if method_name in ["commit_history", "file_change_rates"]:
-                    # Set reasonable defaults if not provided
-                    if "limit" not in method_kwargs:
-                        method_kwargs["limit"] = 100  # Reasonable default for cache warming
-                elif method_name == "list_files":
+                if method_name == "list_files":
                     # list_files doesn't accept limit parameter, remove it if present
                     method_kwargs.pop("limit", None)
 

--- a/tests/test_cache_warming.py
+++ b/tests/test_cache_warming.py
@@ -7,6 +7,7 @@ import tempfile
 import unittest
 from unittest.mock import Mock, patch
 
+import pandas as pd
 from git import Repo
 
 from gitpandas import Repository
@@ -84,7 +85,7 @@ class TestWarmCache(unittest.TestCase):
             self.assertEqual(result["errors"], [])
 
             # Verify methods were called with appropriate arguments
-            mock_commit_history.assert_called_once_with(limit=100)
+            mock_commit_history.assert_called_once_with()
             mock_branches.assert_called_once()
             mock_tags.assert_called_once()
             mock_blame.assert_called_once()
@@ -152,14 +153,13 @@ class TestWarmCache(unittest.TestCase):
             self.assertTrue(result["success"])
             mock_commit_history.assert_called_once_with(limit=50, branch="main", ignore_globs=["*.log"])
 
-    def test_warm_cache_special_method_defaults(self):
-        """Test that special methods get appropriate default arguments."""
+    def test_warm_cache_does_not_add_method_defaults(self):
+        """Test that cache warming preserves the method's own defaults."""
         with patch.object(self.repository, "file_change_rates", return_value=Mock()) as mock_file_change_rates:
             result = self.repository.warm_cache(methods=["file_change_rates"])
 
             self.assertTrue(result["success"])
-            # Should get default limit of 100 for file_change_rates
-            mock_file_change_rates.assert_called_once_with(limit=100)
+            mock_file_change_rates.assert_called_once_with()
 
     def test_warm_cache_cache_entries_tracking(self):
         """Test that cache entries created are properly tracked."""
@@ -244,6 +244,60 @@ class TestWarmCacheIntegration(unittest.TestCase):
 
         # Verify cache has entries
         self.assertGreater(len(cache._cache), 0)
+
+    def test_default_warm_cache_key_is_reused_by_history_and_punchcard(self):
+        repo_path = self._create_repository()
+        cache = EphemeralCache(max_keys=50)
+        repository = Repository(working_dir=repo_path, cache_backend=cache, default_branch="main")
+
+        repository.warm_cache(methods=["commit_history"])
+        history_keys = self._commit_history_keys(cache)
+
+        repository.commit_history()
+        self.assertEqual(self._commit_history_keys(cache), history_keys)
+
+        repository.punchcard()
+        self.assertEqual(self._commit_history_keys(cache), history_keys)
+
+    def test_explicit_limit_warms_matching_commit_history_key(self):
+        repo_path = self._create_repository()
+        cache = EphemeralCache(max_keys=50)
+        repository = Repository(working_dir=repo_path, cache_backend=cache, default_branch="main")
+
+        repository.warm_cache(methods=["commit_history"], limit=50)
+        history_keys = self._commit_history_keys(cache)
+
+        self.assertEqual(len(history_keys), 1)
+        self.assertIn("||50||", next(iter(history_keys)))
+        repository.commit_history(limit=50)
+        self.assertEqual(self._commit_history_keys(cache), history_keys)
+
+    def test_branch_passthrough_preserves_derived_method_results(self):
+        repo_path = self._create_repository()
+
+        for cache_backend in (None, EphemeralCache(max_keys=50)):
+            repository = Repository(working_dir=repo_path, cache_backend=cache_backend, default_branch="main")
+            for method_name in ("hours_estimate", "punchcard", "cumulative_blame"):
+                method = getattr(repository, method_name)
+                pd.testing.assert_frame_equal(method(), method(branch="main"))
+
+    def _create_repository(self):
+        repo_path = os.path.join(self.temp_dir, "cache_key_repo")
+        os.makedirs(repo_path)
+        git_repo = Repo.init(repo_path)
+        git_repo.config_writer().set_value("user", "name", "Test User").release()
+        git_repo.config_writer().set_value("user", "email", "test@example.com").release()
+        git_repo.git.checkout("-b", "main")
+        test_file = os.path.join(repo_path, "test.txt")
+        with open(test_file, "w") as f:
+            f.write("test content")
+        git_repo.index.add(["test.txt"])
+        git_repo.index.commit("Initial commit")
+        return repo_path
+
+    @staticmethod
+    def _commit_history_keys(cache):
+        return {key for key in cache._cache if key.startswith("commit_history||")}
 
     def test_warm_cache_disk_cache(self):
         """Test cache warming with DiskCache."""


### PR DESCRIPTION
Closes #48

## Summary

- stop warm_cache from injecting limit=100, so unparameterized warming populates the natural commit_history key
- pass unresolved branch values through cached internal delegates while retaining resolved names for direct Git access and logging
- add integration coverage for default and explicit-limit warmed keys plus cached/uncached result equality

## Verification

- MPLBACKEND=Agg uv run pytest -m "not slow" — 356 passed, 1 deselected
- uv run ruff check . — passed
- Mutation: restored implicit limit=100 and confirmed the default warm-cache key reuse test failed on the extra limit=None entry
- Mutation: restored default-branch resolution in punchcard and confirmed the same test failed on the extra branch=main entry
