### PR TITLE
Fix first-commit hours allowance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Unreleased
 
 ## Bug Fixes
 
+### Hours Estimation
+ * **FIXED**: `Repository.hours_estimate()` now includes the first-commit allowance, increasing estimates by `single_commit_hours` per contributor and giving single-commit contributors a non-zero estimate.
+
 ### Project Blame Aggregation
  * **FIXED**: `ProjectDirectory.blame()` now preserves committer/author and file grouping keys when combining multiple repositories. Contributors are aggregated by name across repositories, `blame(by="file")` no longer raises `KeyError`, and project-level bus factors are calculated from contributors instead of row numbers.
 

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -340,10 +340,6 @@ class Repository:
             commits = ch[ch[by] == person]
             commits_ts = [x * 10e-10 for x in sorted(commits.index.values.tolist())]
 
-            if len(commits_ts) < 2:
-                ds.append([person, 0])
-                continue
-
             def estimate(index, date, commits_ts):
                 next_ts = commits_ts[index + 1]
                 diff_in_minutes = next_ts - date
@@ -353,7 +349,7 @@ class Repository:
                 return first_commit_addition_in_minutes / 60.0
 
             hours = [estimate(a, b, commits_ts) for a, b in enumerate(commits_ts[:-1])]
-            hours = sum(hours)
+            hours = single_commit_hours + sum(hours)
             ds.append([person, hours])
 
         df = DataFrame(ds, columns=[by, "hours"])

--- a/tests/test_Repository/test_hours_estimate.py
+++ b/tests/test_Repository/test_hours_estimate.py
@@ -1,0 +1,70 @@
+import os
+import subprocess
+
+import pytest
+
+from gitpandas import Repository
+
+
+@pytest.fixture
+def hours_repo(tmp_path):
+    repo_path = tmp_path / "hours-repo"
+    git_env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+    }
+    subprocess.run(["git", "init", "-b", "master", repo_path], check=True, env=git_env, capture_output=True)
+
+    commits = [
+        ("Alice", "alice@example.com", "2024-01-01T09:00:00+00:00"),
+        ("Alice", "alice@example.com", "2024-01-01T09:20:00+00:00"),
+        ("Alice", "alice@example.com", "2024-01-01T09:40:00+00:00"),
+        ("Alice", "alice@example.com", "2024-01-05T09:40:00+00:00"),
+        ("Bob", "bob@example.com", "2024-01-06T09:00:00+00:00"),
+    ]
+    for number, (name, email, timestamp) in enumerate(commits):
+        (repo_path / "work.txt").write_text(f"commit {number}\n")
+        subprocess.run(["git", "-C", repo_path, "add", "work.txt"], check=True, env=git_env, capture_output=True)
+        commit_env = {
+            **git_env,
+            "GIT_AUTHOR_NAME": name,
+            "GIT_AUTHOR_EMAIL": email,
+            "GIT_AUTHOR_DATE": timestamp,
+            "GIT_COMMITTER_NAME": name,
+            "GIT_COMMITTER_EMAIL": email,
+            "GIT_COMMITTER_DATE": timestamp,
+        }
+        subprocess.run(
+            ["git", "-C", repo_path, "commit", "-m", f"commit {number}"],
+            check=True,
+            env=commit_env,
+            capture_output=True,
+        )
+
+    return Repository(working_dir=str(repo_path), default_branch="master")
+
+
+def _hours_by_committer(repo, **kwargs):
+    result = repo.hours_estimate(**kwargs)
+    return result.set_index("committer")["hours"].to_dict()
+
+
+def test_single_commit_contributor_gets_single_commit_allowance(hours_repo):
+    hours = _hours_by_committer(hours_repo)
+
+    assert hours["Bob"] == pytest.approx(0.5)
+
+
+def test_hours_estimate_counts_first_commit_and_new_session(hours_repo):
+    hours = _hours_by_committer(hours_repo)
+
+    assert hours["Alice"] == pytest.approx(0.5 + 1 / 3 + 1 / 3 + 0.5)
+
+
+def test_hours_estimate_scales_single_commit_allowance(hours_repo):
+    default_hours = _hours_by_committer(hours_repo)
+    increased_hours = _hours_by_committer(hours_repo, single_commit_hours=1.0)
+
+    assert increased_hours["Alice"] - default_hours["Alice"] == pytest.approx(1.0)
+    assert increased_hours["Bob"] - default_hours["Bob"] == pytest.approx(0.5)


### PR DESCRIPTION
Closes #46

## Summary

- include the unconditional first-commit allowance in each contributor estimate
- return `single_commit_hours` for contributors with only one commit
- add pinned-timestamp numeric regressions and document the result change

## Verification

- `MPLBACKEND=Agg uv run pytest -m "not slow"` — 356 passed, 1 deselected
- `uv run ruff check .` — passed
- Mutation proof: replaced `single_commit_hours + sum(hours)` with `sum(hours)`, verified the mutation in source, and ran `MPLBACKEND=Agg uv run pytest tests/test_Repository/test_hours_estimate.py -q` — all 3 regression tests failed; restored the implementation and reran the green full gate
