### PR TITLE
Preserve DataFrame indexes in MCP results without mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Unreleased
 
 ## Bug Fixes
 
+### MCP Server Serialization
+ * **FIXED**: `serialize_pandas_object()` dropped every non-datetime DataFrame index during `orient="records"` conversion, so index-carried identity disappeared from tool results (e.g. a blame-shaped frame serialized as `[{"loc": 7}]` without the `committer`/`author` it belongs to). Named index levels, including `MultiIndex` levels such as `file` and `(tag_date, commit_date)`, are now materialized as columns.
+ * **FIXED**: Serialization mutated the DataFrame it was given — rewriting a `DatetimeIndex` into formatted strings and replacing datetime columns in place — which corrupted shared cached frames. Serialization now works on a copy and leaves its input untouched.
+ * **FIXED**: Serializing a frame that keeps a column and index level of the same name (e.g. `file_change_history()`'s `date`) raised `ValueError: cannot insert date, already exists`.
+
 ### Hours Estimation
  * **FIXED**: `Repository.hours_estimate()` now includes the first-commit allowance, increasing estimates by `single_commit_hours` per contributor and giving single-commit contributors a non-zero estimate.
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -163,19 +163,30 @@ def serialize_pandas_object(obj: Any) -> Any:
         JSON-serializable version of the object
     """
     if isinstance(obj, pd.DataFrame):
-        # Handle datetime index/columns
-        if pd.api.types.is_datetime64_any_dtype(obj.index):
-            obj.index = obj.index.strftime("%Y-%m-%dT%H:%M:%SZ")
-            obj = obj.reset_index()
+        # Work on a copy: results may come from the shared repository cache.
+        df = obj.copy()
 
-        for col in obj.select_dtypes(include=["datetime64[ns, UTC]", "datetime64[ns]", "datetimetz"]).columns:
-            if col in obj.columns:
-                obj[col] = obj[col].dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        # Named index levels carry identity (committer, file, tag_date, ...) that
+        # orient="records" would otherwise drop.
+        index_names = list(df.index.names)
+        named_levels = [i for i, name in enumerate(index_names) if name is not None and name not in df.columns]
+        if named_levels:
+            df = df.reset_index(level=named_levels)
+        elif (
+            all(name is None for name in index_names)
+            and not isinstance(df.index, pd.MultiIndex)
+            and pd.api.types.is_datetime64_any_dtype(df.index)
+        ):
+            df = df.reset_index()
 
-        return obj.to_dict(orient="records")
+        for col in df.select_dtypes(include=["datetime64[ns, UTC]", "datetime64[ns]", "datetimetz"]).columns:
+            df[col] = df[col].dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        return df.to_dict(orient="records")
 
     elif isinstance(obj, pd.Series):
         if pd.api.types.is_datetime64_any_dtype(obj.index):
+            obj = obj.copy()
             obj.index = obj.index.strftime("%Y-%m-%dT%H:%M:%SZ")
         return obj.to_dict()
 

--- a/tests/test_mcp_serialization.py
+++ b/tests/test_mcp_serialization.py
@@ -1,0 +1,189 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+@pytest.fixture(scope="module")
+def server():
+    """Import the standalone MCP server with only its FastMCP dependency stubbed."""
+
+    class FastMCPStub:
+        def __init__(self, _name):
+            pass
+
+        def tool(self):
+            return lambda func: func
+
+    mcp_module = types.ModuleType("mcp")
+    mcp_server_module = types.ModuleType("mcp.server")
+    fastmcp_module = types.ModuleType("mcp.server.fastmcp")
+    fastmcp_module.FastMCP = FastMCPStub
+
+    saved = {name: sys.modules.get(name) for name in ("mcp", "mcp.server", "mcp.server.fastmcp")}
+    sys.modules["mcp"] = mcp_module
+    sys.modules["mcp.server"] = mcp_server_module
+    sys.modules["mcp.server.fastmcp"] = fastmcp_module
+    try:
+        server_path = Path(__file__).parents[1] / "mcp_server" / "server.py"
+        spec = importlib.util.spec_from_file_location("gitpandas_mcp_server", server_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def _blame_frame():
+    """Shaped like Repository.blame(by='repository')."""
+    return (
+        pd.DataFrame([["Ada", 7], ["Ada", 3], ["Grace", 5]], columns=["committer", "loc"])
+        .groupby("committer")["loc"]
+        .sum()
+        .to_frame()
+    )
+
+
+def _file_blame_frame():
+    """Shaped like Repository.blame(by='file')."""
+    return (
+        pd.DataFrame(
+            [["Ada", 7, "a.py"], ["Ada", 3, "b.py"], ["Grace", 5, "a.py"]],
+            columns=["committer", "loc", "file"],
+        )
+        .groupby(["committer", "file"])["loc"]
+        .sum()
+        .to_frame()
+    )
+
+
+def test_named_index_is_serialized_as_a_column(server):
+    records = server.serialize_pandas_object(_blame_frame())
+
+    assert records == [
+        {"committer": "Ada", "loc": 10},
+        {"committer": "Grace", "loc": 5},
+    ]
+
+
+def test_named_multiindex_levels_are_serialized_as_columns(server):
+    records = server.serialize_pandas_object(_file_blame_frame())
+
+    assert sorted(records, key=lambda r: (r["committer"], r["file"])) == [
+        {"committer": "Ada", "file": "a.py", "loc": 7},
+        {"committer": "Ada", "file": "b.py", "loc": 3},
+        {"committer": "Grace", "file": "a.py", "loc": 5},
+    ]
+
+
+def test_datetime_index_and_columns_are_json_safe(server):
+    df = pd.DataFrame(
+        {
+            "committer": ["Ada", "Grace"],
+            "last_edit_date": pd.to_datetime(["2024-01-02 03:04:05", "2024-02-03 04:05:06"]),
+        },
+        index=pd.DatetimeIndex(["2024-01-01 00:00:00", "2024-01-02 12:30:00"], name="date"),
+    )
+
+    records = server.serialize_pandas_object(df)
+
+    assert records == [
+        {"date": "2024-01-01T00:00:00Z", "committer": "Ada", "last_edit_date": "2024-01-02T03:04:05Z"},
+        {"date": "2024-01-02T12:30:00Z", "committer": "Grace", "last_edit_date": "2024-02-03T04:05:06Z"},
+    ]
+
+
+def test_unnamed_datetime_index_is_still_emitted(server):
+    df = pd.DataFrame(
+        {"loc": [1, 2]},
+        index=pd.DatetimeIndex(["2024-01-01 00:00:00", "2024-01-02 12:30:00"]),
+    )
+
+    records = server.serialize_pandas_object(df)
+
+    assert records == [
+        {"index": "2024-01-01T00:00:00Z", "loc": 1},
+        {"index": "2024-01-02T12:30:00Z", "loc": 2},
+    ]
+
+
+def test_datetime_multiindex_levels_are_json_safe(server):
+    """Shaped like Repository.commits_in_tags()."""
+    df = pd.DataFrame({"commit_sha": ["abc123"], "tag": ["v1.0.0"]}).set_index(
+        [
+            pd.DatetimeIndex(["2024-01-01 00:00:00"], name="tag_date"),
+            pd.DatetimeIndex(["2023-12-31 23:00:00"], name="commit_date"),
+        ]
+    )
+
+    records = server.serialize_pandas_object(df)
+
+    assert records == [
+        {
+            "tag_date": "2024-01-01T00:00:00Z",
+            "commit_date": "2023-12-31T23:00:00Z",
+            "commit_sha": "abc123",
+            "tag": "v1.0.0",
+        }
+    ]
+
+
+def test_unnamed_range_index_is_not_emitted(server):
+    df = pd.DataFrame({"committer": ["Ada"], "loc": [10]})
+
+    assert server.serialize_pandas_object(df) == [{"committer": "Ada", "loc": 10}]
+
+
+def test_index_level_duplicating_a_column_is_not_reinserted(server):
+    """Shaped like Repository.file_change_history(), which keeps 'date' as index and column."""
+    df = pd.DataFrame(
+        {"date": pd.to_datetime(["2024-01-01 00:00:00"]), "filename": ["a.py"]},
+    ).set_index(pd.DatetimeIndex(["2024-01-01 00:00:00"], name="date"))
+
+    records = server.serialize_pandas_object(df)
+
+    assert records == [{"date": "2024-01-01T00:00:00Z", "filename": "a.py"}]
+
+
+def test_serialization_does_not_mutate_the_input_frame(server):
+    df = pd.DataFrame(
+        {"loc": [1, 2], "last_edit_date": pd.to_datetime(["2024-01-02 03:04:05", "2024-02-03 04:05:06"])},
+        index=pd.DatetimeIndex(["2024-01-01 00:00:00", "2024-01-02 12:30:00"], name="date"),
+    )
+    before = df.copy(deep=True)
+
+    server.serialize_pandas_object(df)
+
+    assert isinstance(df.index, pd.DatetimeIndex)
+    assert df.index.names == before.index.names
+    assert list(df.columns) == list(before.columns)
+    assert df.index.equals(before.index)
+    assert pd.api.types.is_datetime64_any_dtype(df["last_edit_date"])
+    pd.testing.assert_frame_equal(df, before)
+
+
+def test_serialization_does_not_mutate_an_index_bearing_frame(server):
+    df = _file_blame_frame()
+    before = df.copy(deep=True)
+
+    server.serialize_pandas_object(df)
+
+    assert isinstance(df.index, pd.MultiIndex)
+    assert list(df.columns) == ["loc"]
+    pd.testing.assert_frame_equal(df, before)
+
+
+def test_series_with_datetime_index_is_not_mutated(server):
+    series = pd.Series([1, 2], index=pd.DatetimeIndex(["2024-01-01 00:00:00", "2024-01-02 12:30:00"]))
+
+    result = server.serialize_pandas_object(series)
+
+    assert result == {"2024-01-01T00:00:00Z": 1, "2024-01-02T12:30:00Z": 2}
+    assert isinstance(series.index, pd.DatetimeIndex)


### PR DESCRIPTION
Closes #42

`serialize_pandas_object` (`mcp_server/server.py`) emitted DataFrames with `to_dict(orient="records")` and reset the index only when it was datetime-like. Every other index was silently dropped, so any result whose identity lives in the index came back without it. The datetime branch also assigned formatted strings onto `obj.index` and rewrote datetime columns in place — mutating a frame that may have come from the shared repository cache.

## What changed

- Serialization now works on `obj.copy()`, so the input frame (index type, values, names, and datetime columns) is left untouched.
- Every **named** index level — single-level or `MultiIndex` — is materialized as a column before record conversion, so `committer`/`author`, `file`, and `(tag_date, commit_date)` survive.
- Datetime formatting happens on the copy and is applied uniformly to the reset index columns and the frame's own datetime columns, preserving the existing `%Y-%m-%dT%H:%M:%SZ` output.
- An unnamed `DatetimeIndex` still resets into an `index` key (unchanged behaviour); an unnamed `RangeIndex` is still dropped.
- An index level whose name already exists as a column is skipped rather than reinserted. This previously raised `ValueError: cannot insert date, already exists` for `file_change_history()`-shaped frames, i.e. that tool call failed outright.
- `pd.Series` serialization got the same one-line copy fix — it had the identical in-place index mutation.

## Verification

Environment: `uv venv` + `uv pip install -e ".[dev]"`.

**Full repo gate** (matches `.github/workflows/test-suite.yml`):
- `MPLBACKEND=Agg uv run pytest -m "not slow"` → **372 passed, 1 deselected** (was 362 before; 10 new tests).
- `uv run ruff check .` → **All checks passed!**; `uv run ruff format --check` clean on the touched files.

**New tests** (`tests/test_mcp_serialization.py`, importing the standalone server with only FastMCP stubbed, matching the existing pattern in `tests/test_cached_signatures.py`): blame-shaped named index, blame-shaped `(committer, file)` MultiIndex, named datetime index + datetime column, unnamed datetime index, `commits_in_tags`-shaped datetime MultiIndex, unnamed `RangeIndex`, index/column name collision, and three immutability tests (DataFrame with datetime index+column, MultiIndex frame, Series).

**Non-vacuity**: `git stash push mcp_server/` (tests are untracked, so they survive), re-ran the new file → **6 of 10 fail** on the unfixed serializer (dropped named index, dropped MultiIndex levels, dropped datetime MultiIndex levels, the `cannot insert date` ValueError, DataFrame mutation, Series mutation). The remaining 4 are controls for behaviour that must not change. `git stash pop`, all 10 green.

**End-to-end against this repository** through the real serializer (`Repository(".")`), before → after:

| method | before | after |
|---|---|---|
| `blame(by="file")` | `{'loc': 2, 'repository': ...}` | `{'committer': 'GitHub', 'file': '.cursor/rules/project_overview.mdc', 'loc': 2, ...}` |
| `file_change_history(limit=2)` | `ValueError: cannot insert date, already exists` | `{'filename': 'gitpandas/project.py', ..., 'date': '2026-07-23T01:36:47Z', ...}` |
| `commit_history(limit=2)` | records fine, **input mutated** | same records, input unchanged |
| `file_detail()` | records fine, **input mutated** (`last_edit_date` rewritten in place) | same records, input unchanged |

Input-frame equality (`df.equals(before)` plus index type/names) was asserted after each call: `False` for three of the four on the old code, `True` for all four after.

Note: `blame` sits in the MCP server's `exclusion_list`, so it is not itself a registered tool today — it is the clearest example of the shape, and the registered `file_detail` / `file_change_history` / `commits_in_tags` / `commit_history` tools are the ones fixed in practice.
