### PR TITLE
Paginate GitHub profile repository discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Unreleased
  * **FIXED**: Serialization mutated the DataFrame it was given — rewriting a `DatetimeIndex` into formatted strings and replacing datetime columns in place — which corrupted shared cached frames. Serialization now works on a copy and leaves its input untouched.
  * **FIXED**: Serializing a frame that keeps a column and index level of the same name (e.g. `file_change_history()`'s `date`) raised `ValueError: cannot insert date, already exists`.
 
+### GitHub Profile Discovery
+ * **FIXED**: `GitHubProfile` now follows GitHub API pagination links and requests up to 100 repositories per page. If any page fails, discovery returns an empty profile instead of silently analyzing partial results.
+
 ### Hours Estimation
  * **FIXED**: `Repository.hours_estimate()` now includes the first-commit allowance, increasing estimates by `single_commit_hours` per contributor and giving single-commit contributors a non-zero estimate.
 

--- a/gitpandas/project.py
+++ b/gitpandas/project.py
@@ -1547,6 +1547,8 @@ class GitHubProfile(ProjectDirectory):
     Note:
         This class uses the GitHub API to discover repositories. It does not require
         authentication for public repositories, but API rate limits may apply.
+        If any page of repository discovery fails, the profile is initialized empty
+        rather than using incomplete results.
     """
 
     def __init__(self, username, ignore_forks=False, ignore_repos=None, verbose=False):
@@ -1561,15 +1563,19 @@ class GitHubProfile(ProjectDirectory):
         """
         logger.info(f"Initializing GitHubProfile for user '{username}'.")
         # pull the git urls from github's api
-        uri = f"https://api.github.com/users/{username}/repos"
-        logger.debug(f"Fetching repositories from GitHub API: {uri}")
+        next_uri = f"https://api.github.com/users/{username}/repos"
+        params = {"per_page": 100}
+        json_data = []
         try:
-            data = requests.get(uri)
-            data.raise_for_status()  # Raise HTTPError for bad responses (4xx or 5xx)
-            json_data = data.json()
+            while next_uri is not None:
+                logger.debug(f"Fetching repositories from GitHub API: {next_uri}")
+                data = requests.get(next_uri, params=params)
+                data.raise_for_status()  # Raise HTTPError for bad responses (4xx or 5xx)
+                json_data.extend(data.json())
+                next_uri = data.links.get("next", {}).get("url")
+                params = None
         except requests.exceptions.RequestException as e:
             logger.error(f"Failed to fetch GitHub repositories for user {username}: {e}")
-            # Initialize with empty list if API call fails
             ProjectDirectory.__init__(self, working_dir=[], ignore_repos=ignore_repos, verbose=verbose)
             return
 

--- a/tests/test_Project/test_github_profile.py
+++ b/tests/test_Project/test_github_profile.py
@@ -1,0 +1,101 @@
+from unittest.mock import Mock, call, patch
+
+import requests
+
+from gitpandas import GitHubProfile
+
+
+def _response(repositories, next_url=None):
+    response = Mock()
+    response.json.return_value = repositories
+    response.links = {"next": {"url": next_url}} if next_url else {}
+    return response
+
+
+def _repo(name, fork=False):
+    return {"git_url": f"git://github.com/example/{name}.git", "fork": fork}
+
+
+@patch("gitpandas.project.ProjectDirectory.__init__", autospec=True)
+@patch("gitpandas.project.requests.get")
+def test_discovers_repositories_from_all_pages_in_api_order(mock_get, mock_project_init):
+    next_url = "https://api.github.com/users/example/repos?per_page=100&page=2"
+    mock_get.side_effect = [
+        _response([_repo("first"), _repo("second")], next_url),
+        _response([_repo("third")]),
+    ]
+
+    profile = GitHubProfile("example")
+    profile.repos = []
+
+    assert mock_get.call_args_list == [
+        call("https://api.github.com/users/example/repos", params={"per_page": 100}),
+        call(next_url, params=None),
+    ]
+    mock_project_init.assert_called_once_with(
+        profile,
+        working_dir=[
+            "git://github.com/example/first.git",
+            "git://github.com/example/second.git",
+            "git://github.com/example/third.git",
+        ],
+        ignore_repos=None,
+        verbose=False,
+    )
+
+
+@patch("gitpandas.project.ProjectDirectory.__init__", autospec=True)
+@patch("gitpandas.project.requests.get")
+def test_ignore_forks_filters_every_page(mock_get, mock_project_init):
+    next_url = "https://api.github.com/users/example/repos?page=2"
+    mock_get.side_effect = [
+        _response([_repo("first"), _repo("fork-one", fork=True)], next_url),
+        _response([_repo("fork-two", fork=True), _repo("second")]),
+    ]
+
+    profile = GitHubProfile("example", ignore_forks=True)
+    profile.repos = []
+
+    mock_project_init.assert_called_once_with(
+        profile,
+        working_dir=[
+            "git://github.com/example/first.git",
+            "git://github.com/example/second.git",
+        ],
+        ignore_repos=None,
+        verbose=False,
+    )
+
+
+@patch("gitpandas.project.ProjectDirectory.__init__", autospec=True)
+@patch("gitpandas.project.requests.get")
+def test_stops_when_response_has_no_next_link(mock_get, mock_project_init):
+    mock_get.return_value = _response([_repo("only")])
+
+    profile = GitHubProfile("example")
+    profile.repos = []
+
+    mock_get.assert_called_once_with(
+        "https://api.github.com/users/example/repos",
+        params={"per_page": 100},
+    )
+
+
+@patch("gitpandas.project.ProjectDirectory.__init__", autospec=True)
+@patch("gitpandas.project.requests.get")
+def test_later_page_failure_discards_partial_results(mock_get, mock_project_init):
+    next_url = "https://api.github.com/users/example/repos?page=2"
+    mock_get.side_effect = [
+        _response([_repo("partial")], next_url),
+        requests.exceptions.ConnectionError("request failed"),
+    ]
+
+    profile = GitHubProfile("example")
+    profile.repos = []
+
+    mock_project_init.assert_called_once_with(
+        profile,
+        working_dir=[],
+        ignore_repos=None,
+        verbose=False,
+    )


### PR DESCRIPTION
Closes #41

## Summary

- request the GitHub API's maximum repository page size and follow each `next` link
- preserve API repository order while applying `ignore_forks` across the complete collection
- discard all discovered repositories if any pagination request fails, preventing silently partial profiles
- document the failure policy and add mocked, value-based pagination coverage

## Verification

- `uv run pytest tests/test_Project/test_github_profile.py -q` — 4 passed
- `MPLBACKEND=Agg uv run pytest -m "not slow"` — 366 passed, 1 deselected
- `uv run ruff check .` — passed
- non-vacuity check: temporarily reverted `gitpandas/project.py` while retaining the new tests; all 4 pagination tests failed, then passed again after restoring the implementation
