### PR TITLE
Make file_owner honour the committer flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Unreleased
 
 ## Bug Fixes
 
+### File Ownership
+ * **FIXED**: `Repository.file_owner()` always read the commit's *committer* regardless of the `committer` flag, so `committer=False` returned the top committer under a column labelled `author`. It now selects the identity to match the flag, matching `Repository.blame()`. This also fixes `Repository.file_detail(committer=False)` and `ProjectDirectory.file_detail(committer=False)`, whose `file_owner` column reported the committer on rebased, cherry-picked, squash-merged, or web-UI-committed history.
+
 ### MCP Server Serialization
  * **FIXED**: `serialize_pandas_object()` dropped every non-datetime DataFrame index during `orient="records"` conversion, so index-carried identity disappeared from tool results (e.g. a blame-shaped frame serialized as `[{"loc": 7}]` without the `committer`/`author` it belongs to). Named index levels, including `MultiIndex` levels such as `file` and `(tag_date, commit_date)`, are now materialized as columns.
  * **FIXED**: Serialization mutated the DataFrame it was given — rewriting a `DatetimeIndex` into formatted strings and replacing datetime columns in place — which corrupted shared cached frames. Serialization now works on a copy and leaves its input untouched.

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -2311,7 +2311,7 @@ class Repository:
             blame = self.repo.blame(rev, os.path.join(self.git_dir, filename))
             blame = (
                 DataFrame(
-                    [[x[0].committer.name, len(x[1])] for x in blame],
+                    [[(x[0].committer if committer else x[0].author).name, len(x[1])] for x in blame],
                     columns=[cm, "loc"],
                 )
                 .groupby(cm)

--- a/tests/test_Project/test_file_detail_author.py
+++ b/tests/test_Project/test_file_detail_author.py
@@ -1,0 +1,33 @@
+"""Regression tests for ProjectDirectory.file_detail honouring the ``committer`` flag."""
+
+import pytest
+
+from gitpandas import ProjectDirectory
+from gitpandas.cache import EphemeralCache
+from tests.test_Repository.test_file_owner_author import _build_repo
+
+
+@pytest.fixture
+def repos_dir(tmp_path, default_branch):
+    repos_dir = tmp_path / "repos"
+    for repo_number in range(2):
+        _build_repo(repos_dir / f"repo{repo_number}", default_branch)
+    return repos_dir
+
+
+@pytest.fixture(params=[False, True], ids=["uncached", "cached"])
+def project(request, repos_dir, default_branch):
+    cache_backend = EphemeralCache() if request.param else None
+    return ProjectDirectory(working_dir=str(repos_dir), default_branch=default_branch, cache_backend=cache_backend)
+
+
+def test_project_file_detail_respects_committer_flag(project):
+    committer_detail = project.file_detail(committer=True)
+    author_detail = project.file_detail(committer=False)
+
+    expected_files = {("owned.py", "repo0"), ("owned.py", "repo1")}
+    assert set(committer_detail.index) == expected_files
+    assert set(author_detail.index) == expected_files
+
+    assert set(committer_detail["file_owner"]) == {"Bob Committer"}
+    assert set(author_detail["file_owner"]) == {"Alice Author"}

--- a/tests/test_Repository/test_file_owner_author.py
+++ b/tests/test_Repository/test_file_owner_author.py
@@ -1,0 +1,79 @@
+"""Regression tests for file_owner honouring the ``committer`` flag.
+
+The blame extraction in ``Repository.file_owner`` used to always read
+``x[0].committer.name``, so ``committer=False`` returned the top committer
+under a column labelled ``author``.
+"""
+
+import git
+import pytest
+
+from gitpandas import Repository
+from gitpandas.cache import EphemeralCache
+
+AUTHORS = ["Alice Author", "Carol Author"]
+COMMITTERS = ["Bob Committer", "Dave Committer"]
+
+
+def _commit(repo, message, author, committer):
+    """Commit the staged tree with a distinct author and committer."""
+    repo.git.update_environment(
+        GIT_COMMITTER_NAME=committer,
+        GIT_COMMITTER_EMAIL=f"{committer.split()[0].lower()}@example.com",
+    )
+    repo.git.commit(m=message, author=f"{author} <{author.split()[0].lower()}@example.com>")
+
+
+def _build_repo(repo_dir, default_branch, filename="owned.py"):
+    """Build a repo whose top author and top committer are different people."""
+    repo_dir.mkdir(parents=True)
+    repo = git.Repo.init(str(repo_dir))
+    repo.git.config("user.name", "Fallback User")
+    repo.git.config("user.email", "fallback@example.com")
+    repo.git.checkout("-b", default_branch)
+
+    target = repo_dir / filename
+    target.write_text("one\ntwo\nthree\nfour\nfive\n")
+    repo.git.add(all=True)
+    _commit(repo, "majority lines", AUTHORS[0], COMMITTERS[0])
+
+    target.write_text("one\ntwo\nthree\nfour\nfive\nsix\n")
+    repo.git.add(all=True)
+    _commit(repo, "one more line", AUTHORS[1], COMMITTERS[1])
+
+    return repo_dir
+
+
+@pytest.fixture
+def repo_dir(tmp_path, default_branch):
+    return _build_repo(tmp_path / "authored_repo", default_branch)
+
+
+@pytest.fixture(params=[False, True], ids=["uncached", "cached"])
+def repository(request, repo_dir, default_branch):
+    cache_backend = EphemeralCache() if request.param else None
+    repo = Repository(working_dir=str(repo_dir), default_branch=default_branch, cache_backend=cache_backend)
+    yield repo
+    repo.__del__()
+
+
+class TestFileOwnerIdentity:
+    def test_file_owner_respects_committer_flag(self, repository):
+        assert repository.file_owner("HEAD", "owned.py", committer=True) == {"name": "Bob Committer"}
+        assert repository.file_owner("HEAD", "owned.py", committer=False) == {"name": "Alice Author"}
+
+    def test_file_owner_agrees_with_blame(self, repository):
+        for committer in (True, False):
+            column = "committer" if committer else "author"
+            blame = repository.blame(rev="HEAD", committer=committer)
+            top = blame["loc"].idxmax()
+
+            assert blame.index.name == column
+            assert repository.file_owner("HEAD", "owned.py", committer=committer) == {"name": top}
+
+    def test_file_detail_owner_matches_flag(self, repository):
+        committer_detail = repository.file_detail(committer=True)
+        author_detail = repository.file_detail(committer=False)
+
+        assert committer_detail["file_owner"].tolist() == ["Bob Committer"]
+        assert author_detail["file_owner"].tolist() == ["Alice Author"]


### PR DESCRIPTION
Closes #54

`Repository.file_owner()` accepts `committer=True|False` and names its output column
accordingly, but the blame extraction always read `x[0].committer.name` — the `author`
branch was missing. So with `committer=False` the frame was *labelled* `author` but
*filled* with committer names, and `idxmax()` returned the top committer.

`Repository.blame()` already does this correctly (separate committer/author branches),
so the two methods disagreed on the same repo. The bug propagated through
`Repository.file_detail(committer=False)` and `ProjectDirectory.file_detail(committer=False)`,
which report the wrong owner for every file whenever author != committer — the common
case for rebased, cherry-picked, `git am`-applied, squash-merged, or web-UI-committed
history.

## What changed

- `gitpandas/repository.py` — one expression: select the identity to match the flag,
  `(x[0].committer if committer else x[0].author).name`. No signature or column-name
  change; the `author` column simply starts containing authors. `committer=True` (the
  default) is unaffected.
- `tests/test_Repository/test_file_owner_author.py` — new fixture repo whose top author
  (`Alice Author`) and top committer (`Bob Committer`) are different people, built by
  passing `--author` per commit while overriding `GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL`.
  Asserts the two flags return **different, specific names**, that `file_owner` agrees with
  `blame`'s top contributor for both flags, and that `file_detail`'s `file_owner` column
  matches. Parametrized over no-cache and `EphemeralCache()`.
- `tests/test_Project/test_file_detail_author.py` — same assertions against a two-repo
  `ProjectDirectory`, also parametrized cached/uncached.
- `CHANGELOG.md` — new "File Ownership" area under `Unreleased`.

## Verification

- `MPLBACKEND=Agg uv run pytest -m "not slow"` → **380 passed, 1 deselected** (was 372 before
  these 8 new cases).
- `uv run ruff check .` → **All checks passed!**
- **Non-vacuity:** with the source change reverted (`git stash push gitpandas/`, leaving the
  untracked new tests in place) and the old `x[0].committer.name` line confirmed present by
  grep, all **8** new tests fail. Restored → all 8 pass, and the stash pop left the diff
  as shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
