### PR TITLE
Fix punchcard KeyError when no repo yields data

### DIFF
--- a/gitpandas/project.py
+++ b/gitpandas/project.py
@@ -12,7 +12,6 @@ import math
 import os
 import warnings
 
-import numpy as np
 import pandas as pd
 import requests
 from git import GitCommandError
@@ -1161,7 +1160,10 @@ class ProjectDirectory:
         if by is not None:
             aggs.append(by)
 
-        punch_card = df.groupby(aggs).agg({"lines": np.sum, "insertions": np.sum, "deletions": np.sum, "net": np.sum})
+        if df.empty:
+            return pd.DataFrame(columns=aggs + ["lines", "insertions", "deletions", "net"])
+
+        punch_card = df.groupby(aggs).agg({"lines": "sum", "insertions": "sum", "deletions": "sum", "net": "sum"})
         punch_card.reset_index(inplace=True)
 
         # normalize all cols

--- a/tests/test_Project/test_punchcard.py
+++ b/tests/test_Project/test_punchcard.py
@@ -1,0 +1,71 @@
+from unittest.mock import Mock
+
+import pandas as pd
+from git import GitCommandError
+
+from gitpandas import ProjectDirectory
+
+
+def punchcard_chunk(repository, hour, day, lines, insertions, deletions, net):
+    return pd.DataFrame(
+        {
+            "hour_of_day": [hour],
+            "day_of_week": [day],
+            "lines": [lines],
+            "insertions": [insertions],
+            "deletions": [deletions],
+            "net": [net],
+        }
+    )
+
+
+def assert_empty_punchcard(df, by=None):
+    assert df.empty
+    expected_cols = ["hour_of_day", "day_of_week"]
+    if by is not None:
+        expected_cols.append(by)
+    expected_cols += ["lines", "insertions", "deletions", "net"]
+    assert list(df.columns) == expected_cols
+
+
+def test_punchcard_empty_project():
+    project = ProjectDirectory(working_dir=[], verbose=False)
+
+    assert_empty_punchcard(project.punchcard())
+
+
+def test_punchcard_all_repositories_fail():
+    project = ProjectDirectory(working_dir=[], verbose=False)
+    project.repos = [Mock(), Mock()]
+    for repo in project.repos:
+        repo.punchcard.side_effect = GitCommandError("punchcard failed", 128)
+
+    assert_empty_punchcard(project.punchcard())
+
+
+def test_punchcard_no_commits_on_branch():
+    project = ProjectDirectory(working_dir=[], verbose=False)
+    project.repos = [Mock()]
+    project.repos[0].repo_name = "alpha"
+    project.repos[0].punchcard.return_value = pd.DataFrame(
+        columns=["hour_of_day", "day_of_week", "lines", "insertions", "deletions", "net"]
+    )
+
+    assert_empty_punchcard(project.punchcard())
+
+
+def test_punchcard_concatenates_repository_results():
+    project = ProjectDirectory(working_dir=[], verbose=False)
+    project.repos = [Mock(), Mock()]
+    project.repos[0].repo_name = "alpha"
+    project.repos[0].punchcard.return_value = punchcard_chunk("alpha", 9, 0, 10, 8, 2, 6)
+    project.repos[1].repo_name = "beta"
+    project.repos[1].punchcard.return_value = punchcard_chunk("beta", 9, 0, 5, 5, 0, 5)
+
+    result = project.punchcard()
+
+    row = result[(result["hour_of_day"] == 9) & (result["day_of_week"] == 0)].iloc[0]
+    assert row["lines"] == 15
+    assert row["insertions"] == 13
+    assert row["deletions"] == 2
+    assert row["net"] == 11


### PR DESCRIPTION
Fixes #59

## Proposed Changes

  - `ProjectDirectory.punchcard()` returns a schema-preserving empty DataFrame when no repo yields any commits, instead of grouping an empty frame and raising `KeyError: 'hour_of_day'`
  - swapped the four `np.sum` callables in the same `.agg()` call for the string `"sum"`, which silences the `FutureWarning` pandas 2.3 emits for callable aggregators and drops the now-unused `numpy` import
  - added `tests/test_Project/test_punchcard.py` covering an empty project, all-repos-raise-`GitCommandError`, a repo with no commits on the branch, and normal multi-repo concatenation

## Verification
- `pytest tests/test_Project/ -q` -> 89 passed, 1 skipped
- mutation check: reverted `gitpandas/project.py` to the pre-fix version and reran `test_punchcard.py` -> 3 of 4 new tests fail with the exact `KeyError: 'hour_of_day'` from the issue; they pass again with the fix restored
