### PR TITLE
Fix empty ProjectDirectory punchcards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Unreleased
 
 ## Bug Fixes
 
+### Project Punchcard Aggregation
+ * **FIXED**: `ProjectDirectory.punchcard()` now returns a well-formed empty DataFrame when no repository yields commit data and avoids pandas aggregation `FutureWarning`s.
+
 ### File Ownership
  * **FIXED**: `Repository.file_owner()` always read the commit's *committer* regardless of the `committer` flag, so `committer=False` returned the top committer under a column labelled `author`. It now selects the identity to match the flag, matching `Repository.blame()`. This also fixes `Repository.file_detail(committer=False)` and `ProjectDirectory.file_detail(committer=False)`, whose `file_owner` column reported the committer on rebased, cherry-picked, squash-merged, or web-UI-committed history.
 

--- a/gitpandas/project.py
+++ b/gitpandas/project.py
@@ -12,7 +12,6 @@ import math
 import os
 import warnings
 
-import numpy as np
 import pandas as pd
 import requests
 from git import GitCommandError
@@ -1161,7 +1160,11 @@ class ProjectDirectory:
         if by is not None:
             aggs.append(by)
 
-        punch_card = df.groupby(aggs).agg({"lines": np.sum, "insertions": np.sum, "deletions": np.sum, "net": np.sum})
+        metrics = ["lines", "insertions", "deletions", "net"]
+        if df.empty:
+            return pd.DataFrame(columns=[*aggs, *metrics])
+
+        punch_card = df.groupby(aggs).agg(dict.fromkeys(metrics, "sum"))
         punch_card.reset_index(inplace=True)
 
         # normalize all cols

--- a/tests/test_Project/test_punchcard.py
+++ b/tests/test_Project/test_punchcard.py
@@ -1,0 +1,80 @@
+import warnings
+from unittest.mock import Mock
+
+import git
+import pandas as pd
+import pytest
+from git.exc import GitCommandError
+
+from gitpandas import ProjectDirectory
+
+METRICS = ["lines", "insertions", "deletions", "net"]
+
+
+def assert_empty_punchcard(frame, by=None):
+    columns = ["hour_of_day", "day_of_week"]
+    if by is not None:
+        columns.append(by)
+    columns.extend(METRICS)
+
+    assert frame.empty
+    assert list(frame.columns) == columns
+
+
+@pytest.mark.parametrize("by", [None, "committer"])
+def test_punchcard_empty_project(by):
+    project = ProjectDirectory(working_dir=[], verbose=False)
+
+    assert_empty_punchcard(project.punchcard(by=by), by=by)
+
+
+def test_punchcard_all_repositories_fail():
+    project = ProjectDirectory(working_dir=[], verbose=False)
+    project.repos = [Mock(), Mock()]
+    for repo in project.repos:
+        repo.punchcard.side_effect = GitCommandError("punchcard failed", 128)
+
+    assert_empty_punchcard(project.punchcard())
+
+
+@pytest.mark.parametrize("by", [None, "committer"])
+def test_punchcard_repository_without_commits(tmp_path, by):
+    repo_path = tmp_path / "empty-repo"
+    git.Repo.init(repo_path, initial_branch="master")
+    project = ProjectDirectory(working_dir=[str(repo_path)], default_branch="master", verbose=False)
+
+    assert_empty_punchcard(project.punchcard(by=by), by=by)
+
+
+def test_punchcard_aggregates_values_without_future_warning():
+    project = ProjectDirectory(working_dir=[], verbose=False)
+    project.repos = [Mock(repo_name="alpha"), Mock(repo_name="beta")]
+    project.repos[0].punchcard.return_value = pd.DataFrame(
+        {
+            "hour_of_day": [9, 9],
+            "day_of_week": [1, 1],
+            "lines": [10, 5],
+            "insertions": [8, 4],
+            "deletions": [2, 1],
+            "net": [6, 3],
+        }
+    )
+    project.repos[1].punchcard.return_value = pd.DataFrame(
+        {
+            "hour_of_day": [9, 14],
+            "day_of_week": [1, 3],
+            "lines": [7, 20],
+            "insertions": [5, 15],
+            "deletions": [2, 5],
+            "net": [3, 10],
+        }
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        result = project.punchcard()
+
+    assert result.to_dict("records") == [
+        {"hour_of_day": 9, "day_of_week": 1, "lines": 22, "insertions": 17, "deletions": 5, "net": 12},
+        {"hour_of_day": 14, "day_of_week": 3, "lines": 20, "insertions": 15, "deletions": 5, "net": 10},
+    ]


### PR DESCRIPTION
Closes #59

## Summary

- return a success-shaped empty DataFrame when no repository contributes punchcard data
- use pandas string aggregations to preserve values without emitting callable aggregation FutureWarnings
- cover empty projects, no-commit repositories, all-repository Git failures, grouped column shape, and exact multi-repository churn totals

## Verification

- `MPLBACKEND=Agg uv run pytest -m "not slow"` — 403 passed, 1 deselected
- `uv run ruff check .` — passed
- `git diff --check` — passed
- Mutation check: stashed `gitpandas/`; the empty-project tests failed with `KeyError: hour_of_day` and the normal aggregation test failed on `FutureWarning`; restored the source and reran the focused suite — 6 passed
