### PR TITLE
Keep repository in ProjectDirectory.blame(by="file") grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Unreleased
 ### Project Blame Aggregation
  * **FIXED**: `ProjectDirectory.blame()` now preserves committer/author and file grouping keys when combining multiple repositories. Contributors are aggregated by name across repositories, `blame(by="file")` no longer raises `KeyError`, and project-level bus factors are calculated from contributors instead of row numbers.
 
+### Project File Blame Aggregation
+ * **FIXED**: `ProjectDirectory.blame(by="file")` grouped on `(committer/author, file)` only. Because `file` is a repository-relative path, files sharing a path across repositories (`README.md`, `setup.py`, `__init__.py`, ...) were silently summed into a single row reporting a line count that matched neither repository, and the originating repository was discarded entirely. The repository is now part of the grouping, so the result is indexed by `(committer/author, file, repository)` — matching the identification that `file_detail()`, `file_change_rates()`, and `bus_factor(by="file")` already carry. `blame(by="repository")` is unchanged; aggregating a contributor across repositories there remains correct.
+
+**Note**: This adds an index level to `blame(by="file")` output. Code that indexes that result by `(committer, file)` needs updating.
+
 ### Cache Correctness
  * **FIXED**: `@multicache` built cache keys from `kwargs` only, so any argument passed *positionally* was invisible to the key and collapsed to `None`. Keys are now resolved against the decorated method's signature (`inspect.signature().bind()` + `apply_defaults()`), so positional and keyword calls key identically. This fixes:
    - `Repository(working_dir=<master-only repo>, cache_backend=...)` raising `ValueError: Could not detect default branch` — the internal `has_branch("main")` / `has_branch("master")` probes shared one key.

--- a/gitpandas/project.py
+++ b/gitpandas/project.py
@@ -596,9 +596,10 @@ class ProjectDirectory:
                     - committer/author (str): Name of the committer/author
                     - loc (int): Lines of code attributed to that person
                 If by='file':
-                    - committer/author (str): Name of the committer/author
-                    - file (str): File path
+                    Indexed by (committer/author, file, repository) with column:
                     - loc (int): Lines of code attributed to that person in that file
+                    The repository is part of the grouping because file paths are
+                    repository-relative and would otherwise collide across repositories.
 
         Note:
             Results are sorted by lines of code in descending order.
@@ -626,30 +627,25 @@ class ProjectDirectory:
 
         groupby_column = "committer" if committer else "author"
 
+        # File paths are repository-relative, so the repository has to stay in the
+        # grouping or same-named files from different repos get summed together.
+        group_keys = [groupby_column, "file", "repository"] if by == "file" else [groupby_column]
+        empty_columns = [*group_keys, "loc"]
+
         if df is None:
             # No repos, or every repo raised GitCommandError — return an empty
             # DataFrame matching the normal output shape.
-            columns = [groupby_column, "file", "loc"] if by == "file" else [groupby_column, "loc"]
-            return pd.DataFrame(columns=columns)
+            return pd.DataFrame(columns=empty_columns)
 
-        if groupby_column not in df.columns:
+        missing = [column for column in group_keys if column not in df.columns]
+        if missing:
             logger.warning(
-                f"Expected column '{groupby_column}' not found in blame data. Available columns: {df.columns.tolist()}"
+                f"Expected column(s) {missing} not found in blame data. Available columns: {df.columns.tolist()}"
             )
-            # Return empty DataFrame with proper structure if column is missing
-            columns = [groupby_column, "file", "loc"] if by == "file" else [groupby_column, "loc"]
-            return pd.DataFrame(columns=columns)
+            # Return empty DataFrame with proper structure if a grouping column is missing
+            return pd.DataFrame(columns=empty_columns)
 
-        if committer:
-            if by == "repository":
-                df = df.groupby("committer")["loc"].sum().to_frame()
-            elif by == "file":
-                df = df.groupby(["committer", "file"])["loc"].sum().to_frame()
-        else:
-            if by == "repository":
-                df = df.groupby("author")["loc"].sum().to_frame()
-            elif by == "file":
-                df = df.groupby(["author", "file"])["loc"].sum().to_frame()
+        df = df.groupby(group_keys)["loc"].sum().to_frame()
 
         df = df.sort_values(by=["loc"], ascending=False)
         logger.info(f"Calculated blame with {len(df)} rows.")

--- a/tests/test_Project/test_blame_file_detail_empty.py
+++ b/tests/test_Project/test_blame_file_detail_empty.py
@@ -64,7 +64,7 @@ class TestBlameFileDetailAllReposFail:
 
         assert isinstance(blame_df, pd.DataFrame)
         assert blame_df.empty
-        assert list(blame_df.columns) == ["committer", "file", "loc"]
+        assert list(blame_df.columns) == ["committer", "file", "repository", "loc"]
 
     def test_file_detail_all_repos_fail(self, temp_repos):
         """file_detail() returns an empty DataFrame when every repo raises GitCommandError."""

--- a/tests/test_Project/test_blame_multi_repo.py
+++ b/tests/test_Project/test_blame_multi_repo.py
@@ -34,11 +34,11 @@ def test_blame_aggregates_committer_across_repositories(single_author_project):
 def test_blame_by_file_preserves_committer_and_file(single_author_project):
     blame = single_author_project.blame(by="file")
 
-    assert blame.index.names == ["committer", "file"]
+    assert blame.index.names == ["committer", "file", "repository"]
     assert blame["loc"].to_dict() == {
-        ("Alice", "file0.py"): 3,
-        ("Alice", "file1.py"): 3,
-        ("Alice", "file2.py"): 3,
+        ("Alice", "file0.py", "repo0"): 3,
+        ("Alice", "file1.py", "repo1"): 3,
+        ("Alice", "file2.py", "repo2"): 3,
     }
 
 
@@ -53,3 +53,54 @@ def test_project_blame_loc_matches_repository_totals(single_author_project):
     repository_total = sum(repo.blame()["loc"].sum() for repo in single_author_project.repos)
 
     assert project_total == repository_total == 9
+
+
+@pytest.fixture
+def shared_path_project(tmp_path, default_branch):
+    """Two repositories that both contain README.md, with different line counts."""
+    repos_dir = tmp_path / "shared_repos"
+    repos_dir.mkdir()
+
+    contents = {
+        "r1": {"README.md": 10, "one.py": 3},
+        "r2": {"README.md": 5, "two.py": 7},
+    }
+
+    for repo_name, files in contents.items():
+        repo_dir = repos_dir / repo_name
+        repo_dir.mkdir()
+        repo = git.Repo.init(repo_dir)
+        repo.git.config("user.name", "Alice")
+        repo.git.config("user.email", "alice@example.com")
+        for file_name, line_count in files.items():
+            (repo_dir / file_name).write_text("".join(f"line {i}\n" for i in range(line_count)))
+            repo.git.add(file_name)
+        repo.git.commit(m=f"populate {repo_name}")
+
+    return ProjectDirectory(working_dir=str(repos_dir), default_branch=default_branch)
+
+
+def test_blame_by_file_separates_same_named_files_across_repositories(shared_path_project):
+    blame = shared_path_project.blame(by="file")
+
+    assert blame.index.names == ["committer", "file", "repository"]
+    assert blame["loc"].to_dict() == {
+        ("Alice", "README.md", "r1"): 10,
+        ("Alice", "one.py", "r1"): 3,
+        ("Alice", "README.md", "r2"): 5,
+        ("Alice", "two.py", "r2"): 7,
+    }
+
+
+def test_blame_by_file_totals_match_repository_totals(shared_path_project):
+    project_total = shared_path_project.blame(by="file")["loc"].sum()
+    repository_total = sum(repo.blame(by="file")["loc"].sum() for repo in shared_path_project.repos)
+
+    assert project_total == repository_total == 25
+
+
+def test_blame_by_repository_still_aggregates_shared_paths(shared_path_project):
+    blame = shared_path_project.blame()
+
+    assert blame.index.tolist() == ["Alice"]
+    assert blame.loc["Alice", "loc"] == 25


### PR DESCRIPTION
Closes #58

## The bug

`ProjectDirectory.blame(by="file")` grouped on `["committer", "file"]` only. `file` is a
**repository-relative** path, so two repositories that both contain a file at the same relative
path were silently summed into one row. `README.md`, `setup.py`, `__init__.py`, `LICENSE`,
`src/main.py` — collisions are the norm in a multi-repo project, not an edge case.

The `repository` column that `Repository.blame` attaches survives the per-repo `reset_index()`
and was then thrown away by the groupby, so the caller had no way to disambiguate or to recover
the per-repo split.

On a two-repo fixture (one committer, `README.md` with 10 lines in `r1` and 5 in `r2`) the old
output reported a single `("Alice", "README.md")` row with `loc` 15 — a line count that matched
neither repository — with no `repository` identifier anywhere in the result.

## What changed

`gitpandas/project.py`

- The `by="file"` path now groups on `[committer|author, "file", "repository"]`, so the result is
  indexed by `(committer/author, file, repository)`. No new data is collected — the column was
  already on the concatenated frame.
- The two empty-frame shapes (all-repos-fail / empty project, and the missing-grouping-column
  guard) gained `repository` to match. The guard now reports every missing grouping column
  rather than just the committer/author one.
- The two `if committer: / else:` branches collapsed into one `groupby(group_keys)` — they
  differed only in the name of the first key.
- Docstring return shape updated.

`by="repository"` is untouched: summing a committer across repositories there is correct and
intended.

## Behaviour change

This adds an index level to `blame(by="file")` output. That is unavoidable — the current output
is wrong, and there is no way to report per-repo file blame without carrying the repository. It
mirrors the shape `file_detail` already uses (`(file, repository)`), and `by="repository"` — the
default and by far the more common call — is unchanged. Called out in `CHANGELOG.md` under a new
`### Project File Blame Aggregation` heading, with an explicit note that code indexing the result
by `(committer, file)` needs updating.

## Tests

`tests/test_Project/test_blame_multi_repo.py` gains a `shared_path_project` fixture — two repos
that **both** contain `README.md` (10 lines vs 5), plus a unique file each — and three tests
asserting exact per-`(committer, file, repository)` LOC values, that the `by="file"` total still
equals the sum of the per-repo `Repository.blame(by="file")` totals, and that `by="repository"`
still aggregates the same committer across both repos.

Two existing tests were updated for the new shape (both were asserting the old index):
`test_blame_by_file_preserves_committer_and_file` and `test_blame_by_file_all_repos_fail`. The
`by="repository"` tests named in the issue are untouched.

## Verification

- `MPLBACKEND=Agg uv run pytest -m "not slow"` → **400 passed, 1 deselected**
- `uv run ruff check .` → **All checks passed!**
- **Non-vacuity**: with the source change stashed (`git stash push gitpandas/`), the new
  collision test `test_blame_by_file_separates_same_named_files_across_repositories` fails (it
  gets one merged `README.md` row of 15 instead of two rows of 10 and 5), as do the two updated
  shape tests — 3 failed, 9 passed. Restored, all 12 pass.
  Note `test_blame_by_file_totals_match_repository_totals` passes on both sides by design: the
  LOC sum is preserved either way, so that test documents the invariant rather than guarding the
  fix. The collision test is the one carrying the behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)