### PR TITLE
Fix file change history churn counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Unreleased
 
 ## Bug Fixes
 
+### File Change History
+ * **FIXED**: `Repository.file_change_history()` now reports actual per-file insertions and deletions, including root commits, which restores non-zero churn metrics in `file_change_rates()`.
+
 ### Project Punchcard Aggregation
  * **FIXED**: `ProjectDirectory.punchcard()` now returns a well-formed empty DataFrame when no repository yields commit data and avoids pandas aggregation `FutureWarning`s.
 

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -685,7 +685,11 @@ class Repository:
 
         # Process each file in the commit
         try:
-            diffs = commit.diff(parent) if parent else commit.diff(git.NULL_TREE)
+            diffs = (
+                parent.diff(commit, create_patch=True)
+                if parent
+                else commit.diff(git.NULL_TREE, create_patch=True)
+            )
 
             for diff in diffs:
                 try:
@@ -706,30 +710,22 @@ class Repository:
                     insertions = 0
                     deletions = 0
                     try:
-                        # Check if diff has stats attribute first
-                        if hasattr(diff, "stats"):
-                            stats = diff.stats
-                            insertions = stats.get("insertions", 0)
-                            deletions = stats.get("deletions", 0)
+                        diff_content = diff.diff
+                        # Check if diff.diff is bytes or string
+                        if isinstance(diff_content, bytes):
+                            diff_lines = diff_content.decode("utf-8", errors="replace").splitlines()
+                        elif isinstance(diff_content, str):
+                            diff_lines = diff_content.splitlines()
                         else:
-                            # Alternative approach for newer GitPython versions where stats may not be available
-                            # Calculate insertions and deletions manually from the diff
-                            diff_content = diff.diff
-                            # Check if diff.diff is bytes or string
-                            if isinstance(diff_content, bytes):
-                                diff_lines = diff_content.decode("utf-8", errors="replace").splitlines()
-                            elif isinstance(diff_content, str):
-                                diff_lines = diff_content.splitlines()
-                            else:
-                                # If it's neither bytes nor string, we can't process it
-                                logger.warning(f"Diff content has unexpected type: {type(diff_content)}")
-                                continue
+                            # If it's neither bytes nor string, we can't process it
+                            logger.warning(f"Diff content has unexpected type: {type(diff_content)}")
+                            continue
 
-                            for line in diff_lines:
-                                if line.startswith("+") and not line.startswith("+++"):
-                                    insertions += 1
-                                elif line.startswith("-") and not line.startswith("---"):
-                                    deletions += 1
+                        for line in diff_lines:
+                            if line.startswith("+") and not line.startswith("+++"):
+                                insertions += 1
+                            elif line.startswith("-") and not line.startswith("---"):
+                                deletions += 1
                     except (ValueError, AttributeError, KeyError, UnicodeDecodeError) as e:
                         if skip_broken:
                             logger.warning(f"Error getting diff stats for {path} in commit {hexsha}: {e}")

--- a/tests/test_Repository/test_file_change_history_values.py
+++ b/tests/test_Repository/test_file_change_history_values.py
@@ -1,0 +1,63 @@
+import datetime
+
+import pytest
+from git import Repo
+
+from gitpandas import Repository
+
+
+@pytest.fixture
+def change_history_repo(tmp_path):
+    repo_path = tmp_path / "change_history"
+    repo = Repo.init(repo_path, initial_branch="master")
+    repo.config_writer().set_value("user", "name", "Test User").release()
+    repo.config_writer().set_value("user", "email", "test@example.com").release()
+
+    contents = [
+        ("root", "a\nb\nc\n"),
+        ("add", "a\nb\nc\nd\ne\n"),
+        ("delete", "a\nb\nd\ne\n"),
+        ("mixed", "a\nB\nd\ne\nf\n"),
+    ]
+    start = datetime.datetime(2023, 1, 1, tzinfo=datetime.timezone.utc)
+    for offset, (message, content) in enumerate(contents):
+        (repo_path / "f.txt").write_text(content)
+        repo.index.add(["f.txt"])
+        commit_date = int((start + datetime.timedelta(hours=offset)).timestamp())
+        repo.index.commit(message, commit_date=f"{commit_date} +0000")
+
+    return Repository(working_dir=str(repo_path), default_branch="master")
+
+
+def test_file_change_history_reports_exact_churn(change_history_repo):
+    history = change_history_repo.file_change_history(branch="master")
+    actual = {
+        row.message: (row.insertions, row.deletions, row.lines)
+        for row in history.itertuples()
+    }
+
+    assert actual == {
+        "root": (3, 0, 3),
+        "add": (2, 0, 2),
+        "delete": (0, 1, -1),
+        "mixed": (2, 1, 1),
+    }
+
+
+def test_file_change_history_totals_match_commit_history(change_history_repo):
+    file_history = change_history_repo.file_change_history(branch="master")
+    file_totals = file_history.groupby("message")[["insertions", "deletions"]].sum()
+    commit_history = change_history_repo.commit_history(branch="master").set_index("message")
+
+    for message in ["root", "add", "delete", "mixed"]:
+        assert tuple(file_totals.loc[message]) == (
+            commit_history.loc[message, "insertions"],
+            commit_history.loc[message, "deletions"],
+        )
+
+
+def test_file_change_rates_reports_nonzero_churn(change_history_repo):
+    rates = change_history_repo.file_change_rates(branch="master").set_index("file")
+
+    assert rates.loc["f.txt", "abs_change"] == 9
+    assert rates.loc["f.txt", "net_change"] == 5


### PR DESCRIPTION
Closes #34

## Summary

- generate patch content for per-file diffs and compare parents to commits in chronological direction
- count root commit contents as insertions and remove the dead `Diff.stats` path
- add exact-value coverage for root, add-only, delete-only, and mixed commits, churn rates, and agreement with commit-level totals
- document the corrected metrics in the changelog

## Verification

- `MPLBACKEND=Agg uv run pytest -m "not slow"` — 409 passed, 1 deselected
- `uv run ruff check .` — passed
- Regression mutation: restored the original no-patch/reversed diff call and ran `MPLBACKEND=Agg uv run pytest -q tests/test_Repository/test_file_change_history_values.py` — all 3 tests failed; restored the fix and the same tests passed
