### PR TITLE
Fix duplicate rows in cumulative blame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Unreleased
 
 ## Bug Fixes
 
+### Cumulative Blame
+ * **FIXED**: `Repository.cumulative_blame()` and `parallel_cumulative_blame()` no longer duplicate rows when multiple commits share a timestamp.
+
 ### File Change History
  * **FIXED**: `Repository.file_change_history()` now reports actual per-file insertions and deletions, including root commits, which restores non-zero churn metrics in `file_change_rates()`.
 

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -1426,9 +1426,9 @@ class Repository:
                     del revs[col]
 
             # drop 0 rows
-            keep_idx = []
+            keep_positions = []
             committers = [x for x in revs.columns.values if x != "date"]
-            for idx, row in revs.iterrows():
+            for position, (_, row) in enumerate(revs.iterrows()):
                 # Convert any string values to numeric, treating non-numeric strings as 0
                 row_sum = 0
                 for x in committers:
@@ -1438,13 +1438,13 @@ class Repository:
                     except (ValueError, TypeError):
                         continue
                 if row_sum > 0:
-                    keep_idx.append(idx)
+                    keep_positions.append(position)
 
-            logger.debug(f"Filtering complete. Kept {len(keep_idx)} non-zero rows.")
+            logger.debug(f"Filtering complete. Kept {len(keep_positions)} non-zero rows.")
 
             # Only filter if we have rows to keep
-            if keep_idx:
-                revs = revs.loc[keep_idx]
+            if keep_positions:
+                revs = revs.iloc[keep_positions]
         except Exception as e:
             logger.error(f"Error processing cumulative blame data: {e}")
             return pd.DataFrame(index=pd.to_datetime([]).tz_localize("UTC"))
@@ -1548,9 +1548,9 @@ class Repository:
                     del revs[col]
 
             # drop 0 rows
-            keep_idx = []
+            keep_positions = []
             committers = [x for x in revs.columns.values if x != "date"]
-            for idx, row in revs.iterrows():
+            for position, (_, row) in enumerate(revs.iterrows()):
                 # Convert any string values to numeric, treating non-numeric strings as 0
                 row_sum = 0
                 for x in committers:
@@ -1560,13 +1560,13 @@ class Repository:
                     except (ValueError, TypeError):
                         continue
                 if row_sum > 0:
-                    keep_idx.append(idx)
+                    keep_positions.append(position)
 
-            logger.debug(f"Filtering complete. Kept {len(keep_idx)} non-zero rows.")
+            logger.debug(f"Filtering complete. Kept {len(keep_positions)} non-zero rows.")
 
             # Only filter if we have rows to keep
-            if keep_idx:
-                revs = revs.loc[keep_idx]
+            if keep_positions:
+                revs = revs.iloc[keep_positions]
 
             logger.info(f"Finished parallel cumulative blame for '{branch}'. Result shape: {revs.shape}")
             return revs

--- a/tests/test_Repository/test_cumulative_blame_duplicate_dates.py
+++ b/tests/test_Repository/test_cumulative_blame_duplicate_dates.py
@@ -1,0 +1,43 @@
+import datetime
+
+import pytest
+from git import Actor, Repo
+
+from gitpandas import Repository
+
+
+def _build_linear_repo(path, shared_timestamp):
+    git_repo = Repo.init(path)
+    git_repo.git.checkout(b="main")
+    actor = Actor("Test Author", "test@example.com")
+    base_timestamp = int(datetime.datetime(2023, 1, 1, tzinfo=datetime.timezone.utc).timestamp())
+    test_file = path / "history.txt"
+
+    for line_count in range(1, 6):
+        timestamp = base_timestamp if shared_timestamp else base_timestamp + (line_count * 3600)
+        test_file.write_text("".join(f"line {line}\n" for line in range(1, line_count + 1)))
+        git_repo.index.add(["history.txt"])
+        git_repo.index.commit(
+            f"Add line {line_count}",
+            author=actor,
+            committer=actor,
+            author_date=f"{timestamp} +0000",
+            commit_date=f"{timestamp} +0000",
+        )
+
+
+@pytest.mark.parametrize("method_name", ["cumulative_blame", "parallel_cumulative_blame"])
+@pytest.mark.parametrize("shared_timestamp", [True, False], ids=["duplicate-dates", "distinct-dates"])
+def test_cumulative_blame_preserves_each_revision(tmp_path, method_name, shared_timestamp):
+    repo_path = tmp_path / "linear_repo"
+    repo_path.mkdir()
+    _build_linear_repo(repo_path, shared_timestamp)
+    repo = Repository(working_dir=str(repo_path), default_branch="main")
+
+    revs = repo.revs(branch="main")
+    result = getattr(repo, method_name)(branch="main", workers=2) if method_name.startswith("parallel") else getattr(
+        repo, method_name
+    )(branch="main")
+
+    assert len(result) == len(revs) == 5
+    assert result["Test Author"].tolist() == [5, 4, 3, 2, 1]


### PR DESCRIPTION
Closes #53

## Summary

- retain cumulative-blame rows by positional offset instead of datetime index label
- apply the same correction to serial and parallel cumulative blame
- cover five-commit histories with duplicate and distinct timestamps, asserting exact LOC progression and revision counts
- document the fix in the changelog

## Verification

- `MPLBACKEND=Agg uv run pytest -m "not slow"` — 413 passed, 1 deselected
- `uv run ruff check .` — passed
- `git diff --check` — passed
- Reverted the production source change while leaving the new tests in place and verified the mutation landed by finding both `revs.loc[keep_idx]` call sites. The two duplicate-date cases failed with 25 rows instead of 5 for `cumulative_blame` and `parallel_cumulative_blame`; both distinct-date controls passed. Restored the source change and reran the full green suite above.