### PR TITLE
Stop cumulative_blame from mutating cached DataFrames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ Unreleased
 
 **Note**: This adds an index level to `blame(by="file")` output. Code that indexes that result by `(committer, file)` needs updating.
 
+### Cumulative Blame Cache Mutation
+ * **FIXED**: `Repository.cumulative_blame()` reshaped the `revs()` frame it received in place — adding a column per committer, deleting `rev`, and replacing the index with the commit dates. Because a cache backend hands out the stored DataFrame by reference, a later `revs()` call returned that wrecked frame, and a *second* `cumulative_blame()` call raised `ValueError: Internal Error: self.revs() returned DataFrame without 'rev' column.` (`parallel_cumulative_blame()` swallowed the same failure and returned an empty DataFrame). It now works on a copy.
+ * **FIXED**: `ProjectDirectory.cumulative_blame()` renamed each member repository's cached `cumulative_blame()` columns in place while suffixing them with the repository name, so a later per-repository call returned `Alice__repo1` instead of `Alice`. The suffixing now happens on copies.
+
 ### Cache Correctness
  * **FIXED**: `@multicache` built cache keys from `kwargs` only, so any argument passed *positionally* was invisible to the key and collapsed to `None`. Keys are now resolved against the decorated method's signature (`inspect.signature().bind()` + `apply_defaults()`), so positional and keyword calls key identically. This fixes:
    - `Repository(working_dir=<master-only repo>, cache_backend=...)` raising `ValueError: Could not detect default branch` — the internal `has_branch("main")` / `has_branch("master")` probes shared one key.

--- a/gitpandas/project.py
+++ b/gitpandas/project.py
@@ -863,11 +863,11 @@ class ProjectDirectory:
             else:  # by == 'raw'
                 return pd.DataFrame()
 
-        global_blame = blames[0][1]
-        global_blame.columns = [x + "__" + str(blames[0][0]) for x in global_blame.columns.values]
+        # each per-repo frame may be served from the cache by reference, so rename onto copies
+        global_blame = blames[0][1].rename(columns=lambda x: f"{x}__{blames[0][0]}")
         blames = blames[1:]
         for reponame, blame in blames:
-            blame.columns = [x + "__" + reponame for x in blame.columns.values]
+            blame = blame.rename(columns=lambda x, reponame=reponame: f"{x}__{reponame}")
             global_blame = pd.merge(global_blame, blame, left_index=True, right_index=True, how="outer")
 
         global_blame = global_blame.ffill()

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -1328,6 +1328,8 @@ class Repository:
 
         # Pass skip_broken and force_refresh to ensure robustness when getting revisions
         revs = self.revs(branch=branch, limit=limit, skip=skip, num_datapoints=num_datapoints, skip_broken=skip_broken)
+        # revs() may be served from the cache by reference, and this method writes into the frame
+        revs = revs.copy()
 
         # Check immediately after calling revs()
         if not revs.empty and "rev" not in revs.columns:

--- a/tests/test_cache_immutability.py
+++ b/tests/test_cache_immutability.py
@@ -112,6 +112,60 @@ class TestCacheImmutability:
 
         _assert_unchanged(cached_repo.cache_backend, snapshot)
 
+    def test_cumulative_blame_does_not_mutate_cached_revs(self, cached_repo, default_branch):
+        """cumulative_blame() reshapes the revs() frame it borrows; the cache must keep the original."""
+        before = cached_repo.revs(branch=default_branch, skip_broken=True).copy()
+        snapshot = _snapshot(cached_repo.cache_backend)
+        assert snapshot, "expected revs to be cached"
+
+        blame = cached_repo.cumulative_blame(branch=default_branch)
+        assert not blame.empty
+
+        after = cached_repo.revs(branch=default_branch, skip_broken=True)
+        assert list(after.columns) == ["date", "rev", "repository"]
+        assert isinstance(after.index, pd.RangeIndex)
+        assert after.equals(before)
+        _assert_unchanged(cached_repo.cache_backend, snapshot)
+
+    def test_successive_cumulative_blame_calls_both_return_data(self, cached_repo, default_branch):
+        """The second call re-reads revs() from the cache, so a mutated frame breaks it outright."""
+        first = cached_repo.cumulative_blame(branch=default_branch, committer=True)
+        second = cached_repo.cumulative_blame(branch=default_branch, committer=False)
+
+        assert not first.empty
+        assert not second.empty
+        assert first.shape[0] == second.shape[0] == 4
+
+    def test_parallel_cumulative_blame_after_cumulative_blame(self, cached_repo, default_branch):
+        """parallel_cumulative_blame swallows the poisoned-revs failure and returns an empty frame."""
+        pytest.importorskip("joblib")
+
+        assert not cached_repo.cumulative_blame(branch=default_branch).empty
+
+        parallel = cached_repo.parallel_cumulative_blame(branch=default_branch)
+        assert not parallel.empty
+        assert parallel.shape[0] == 4
+
+    def test_project_cumulative_blame_does_not_rename_cached_repo_frames(self, cached_project, default_branch):
+        """The project aggregation suffixes column names per repo; the cached frames must keep theirs."""
+        before = {}
+        for repo in cached_project.repos:
+            frame = repo.cumulative_blame(branch=default_branch)
+            before[repo.repo_name] = (list(frame.columns), frame.copy())
+
+        snapshots = {repo.repo_name: _snapshot(repo.cache_backend) for repo in cached_project.repos}
+        assert all(snapshots.values()), "expected per-repo cumulative_blame to be cached"
+
+        assert not cached_project.cumulative_blame(branch=default_branch).empty
+
+        for repo in cached_project.repos:
+            columns, frame = before[repo.repo_name]
+            after = repo.cumulative_blame(branch=default_branch)
+            assert list(after.columns) == columns
+            assert not any("__" in str(col) for col in after.columns)
+            assert after.equals(frame)
+            _assert_unchanged(repo.cache_backend, snapshots[repo.repo_name])
+
     def test_project_methods_do_not_mutate_cached_repo_frames(self, cached_project, default_branch):
         """ProjectDirectory aggregation must leave each member repo's cached frames alone."""
         for repo in cached_project.repos:


### PR DESCRIPTION
Closes #52

Cache backends return stored DataFrames **by reference**, so any in-place write on a `@multicache`-decorated method's result rewrites every later cache hit. `cumulative_blame` was the remaining offender, and it did not merely add a column — it destroyed the frame it borrowed.

## What changed

- `gitpandas/repository.py` — `Repository.cumulative_blame` now copies the `revs()` frame before writing into it. Previously it added a column per committer, wrote values with `.at`, `del`'d the `rev` column, and replaced the index with the commit dates, all on the cached object.
- `gitpandas/project.py` — `ProjectDirectory.cumulative_blame` suffixes column names with `rename(columns=...)` instead of assigning `.columns` on the borrowed per-repo frames.
- `tests/test_cache_immutability.py` — four new tests, reusing the existing `_snapshot`/`_assert_unchanged` helpers and the two-repo `cached_project` fixture. All pass `branch` explicitly, since `cumulative_blame` resolves `branch=None` to the default branch before delegating and a `None` test would populate a different cache key and pass vacuously.
- `CHANGELOG.md` — new `### Cumulative Blame Cache Mutation` area under `Unreleased`.

## One deviation from the issue's proposed change

The issue also proposed `revs = revs.copy()` in `parallel_cumulative_blame`. I left that method alone: it never writes into the borrowed frame — it only reads it via `to_json`, then rebinds `revs = DataFrame(ds)` *before* the `del revs["rev"]` / `set_index` writes, which therefore land on a freshly built frame. Verified directly on a fresh cache: `parallel_cumulative_blame()` alone leaves the cached `revs()` entry byte-identical (`['date', 'rev', 'repository']`, `RangeIndex`). Adding a `.copy()` there would have been inert code, so the acceptance criterion for `parallel_cumulative_blame` is carried entirely by the `cumulative_blame` fix — its `except Exception` was swallowing a `KeyError: 'rev'` raised on the frame `cumulative_blame` had already wrecked.

`ProjectDirectory.cumulative_blame`'s own output is unchanged by the rename fix (same columns, same shape) — it filters non-numeric columns with `pd.to_numeric(errors="raise")` downstream either way.

## Verification

Reproduction, before and after, on a 4-commit fixture repo with `cache_backend=EphemeralCache()` and a two-repo `ProjectDirectory` sharing one backend:

| probe | before | after |
|---|---|---|
| `revs(branch="master", skip_broken=True)` after `cumulative_blame()` | `['repository', 'A']`, `DatetimeIndex` | `['date', 'rev', 'repository']`, `RangeIndex` |
| second `cumulative_blame(committer=False)` | `ValueError: Internal Error: self.revs() returned DataFrame without 'rev' column.` | shape `(4, 2)` |
| `parallel_cumulative_blame()` after `cumulative_blame()` | shape `(0, 0)` | shape `(4, 2)` |
| per-repo `cumulative_blame()` after `ProjectDirectory.cumulative_blame()` | `['repository__r1', 'A__r1']` | `['repository', 'A']` |

**Non-vacuity of the new tests** (`git stash push gitpandas/` — the source half only, since the tests are already staged/untracked relative to it — then run, then `git stash pop`): **4 failed, 3 passed**. The three that passed are the pre-existing `punchcard`/project tests. Each new test went red on its own assertion:

- `test_cumulative_blame_does_not_mutate_cached_revs` — `AssertionError: assert ['repository', 'Test User'] == ['date', 'rev', 'repository']`
- `test_successive_cumulative_blame_calls_both_return_data` — `ValueError: Internal Error: self.revs() returned DataFrame without 'rev' column.` (raised from `repository.py`, not an assertion)
- `test_parallel_cumulative_blame_after_cumulative_blame` — `assert not True` on `assert not parallel.empty`, with `ERROR gitpandas: Error in parallel cumulative blame: 'rev'` logged
- `test_project_cumulative_blame_does_not_rename_cached_repo_frames` — `AssertionError: assert ['repository__repository1', ...] == ['repository', 'Test User']`

Full gate with the fix in place:

- `MPLBACKEND=Agg pytest -m "not slow"` → **413 passed, 1 deselected** (unchanged from the base branch's count)
- `ruff check .` → **All checks passed!**