### PR TITLE
Fix targeted repository cache invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Unreleased
  * **FIXED**: `ProjectDirectory.cumulative_blame()` renamed each member repository's cached `cumulative_blame()` columns in place while suffixing them with the repository name, so a later per-repository call returned `Alice__repo1` instead of `Alice`. The suffixing now happens on copies.
 
 ### Cache Correctness
+ * **FIXED**: `Repository.invalidate_cache()` now targets the method-first cache key layout, processes every key when combined with a pattern, and returns accurate removal counts for in-memory and Redis backends.
  * **FIXED**: `@multicache` built cache keys from `kwargs` only, so any argument passed *positionally* was invisible to the key and collapsed to `None`. Keys are now resolved against the decorated method's signature (`inspect.signature().bind()` + `apply_defaults()`), so positional and keyword calls key identically. This fixes:
    - `Repository(working_dir=<master-only repo>, cache_backend=...)` raising `ValueError: Could not detect default branch` — the internal `has_branch("main")` / `has_branch("master")` probes shared one key.
    - `file_detail()` reporting the first file's owner for every file — the internal `file_owner(rev, file_path, ...)` calls shared one key.

--- a/gitpandas/cache.py
+++ b/gitpandas/cache.py
@@ -310,9 +310,10 @@ class EphemeralCache:
 
         if keys is None and pattern is None:
             # Clear all cache entries
+            count = len(self._cache)
             self._cache.clear()
             self._key_list.clear()
-            return len(self._cache)
+            return count
 
         keys_to_remove = []
 
@@ -774,11 +775,11 @@ class RedisDFCache:
 
         if keys is None and pattern is None:
             # Clear all cache entries
-            for key in list(self._key_list):
-                if key.startswith(self.prefix):
-                    self._cache.delete(key)
+            keys_to_remove = [key for key in self._key_list if key.startswith(self.prefix)]
+            for key in keys_to_remove:
+                self._cache.delete(key)
             self._key_list = [k for k in self._key_list if not k.startswith(self.prefix)]
-            return
+            return len(keys_to_remove)
 
         keys_to_remove = []
 

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -3004,15 +3004,15 @@ class Repository:
             logger.warning(f"Cache backend {type(self.cache_backend).__name__} does not support cache invalidation")
             return 0
 
-        # If specific keys provided, prefix them with repo name
+        # If specific keys provided, scope them to this repository
         prefixed_keys = None
         if keys:
-            prefixed_keys = [f"*||{self.repo_name}||*{key}*" if not key.startswith("*") else key for key in keys]
+            prefixed_keys = [f"{key}||{self.repo_name}||*" for key in keys]
 
-        # If pattern provided, include repo name in pattern
+        # If pattern provided, scope it to this repository
         repo_pattern = None
         if pattern:
-            repo_pattern = f"*||{self.repo_name}||*{pattern}*"
+            repo_pattern = f"{pattern}||{self.repo_name}||*"
         elif keys is None:
             # No keys or pattern specified, invalidate all for this repo
             repo_pattern = f"*||{self.repo_name}||*"
@@ -3021,7 +3021,7 @@ class Repository:
             if prefixed_keys and repo_pattern:
                 # Both keys and pattern specified
                 count1 = self.cache_backend.invalidate_cache(pattern=repo_pattern)
-                count2 = self.cache_backend.invalidate_cache(pattern=prefixed_keys[0] if prefixed_keys else None)
+                count2 = sum(self.cache_backend.invalidate_cache(pattern=key) for key in prefixed_keys)
                 return count1 + count2
             elif prefixed_keys:
                 # Only keys specified

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -401,6 +401,20 @@ class TestRedisDFCache:
         mock_redis_instance.delete.assert_any_call(b"gitpandas_key1")
         mock_redis_instance.delete.assert_any_call(b"gitpandas_key2")
 
+    @patch("gitpandas.cache._HAS_REDIS", True)
+    @patch("gitpandas.cache.redis.StrictRedis")
+    def test_invalidate_cache_returns_clear_count(self, mock_redis):
+        """Test clearing Redis cache returns the number of deleted entries."""
+        mock_redis_instance = MagicMock()
+        mock_redis.return_value = mock_redis_instance
+        mock_redis_instance.keys.return_value = [b"gitpandas_key1", b"gitpandas_key2"]
+
+        cache = RedisDFCache()
+
+        assert cache.invalidate_cache() == 2
+        assert cache._key_list == []
+        assert mock_redis_instance.delete.call_count == 2
+
 
 class MockRepoMethod:
     """Class that simulates a repository object with a cached method."""

--- a/tests/test_cache_management.py
+++ b/tests/test_cache_management.py
@@ -35,6 +35,7 @@ class TestCacheManagement:
 
         # Test clearing all
         removed = cache.invalidate_cache()
+        assert removed == 1
         assert len(cache._cache) == 0
 
     def test_cache_stats_ephemeral(self):
@@ -85,19 +86,52 @@ class TestCacheManagement:
         # Warm cache
         repo.commit_history(limit=5)
         repo.branches()
+        repo.blame()
 
-        initial_cache_size = len(cache._cache)
-        assert initial_cache_size > 0
+        assert sorted(cache._cache) == [
+            "blame||test_repo||HEAD||True||repository||None||None",
+            "branches||test_repo||",
+            "commit_history||test_repo||None||5||None||None||None",
+        ]
 
         # Test invalidating specific cache type
         removed = repo.invalidate_cache(keys=["commit_history"])
-        assert removed >= 0  # Should find and remove commit_history cache entries
+        assert removed == 1
+        assert sorted(cache._cache) == [
+            "blame||test_repo||HEAD||True||repository||None||None",
+            "branches||test_repo||",
+        ]
 
-        # Test invalidating all repo cache
+        # Test invalidating by pattern
+        removed = repo.invalidate_cache(pattern="blame*")
+        assert removed == 1
+        assert sorted(cache._cache) == ["branches||test_repo||"]
+
+        # Test invalidating all repository cache
         removed = repo.invalidate_cache()
-        # After invalidation, we should have fewer or zero cache entries for this repo
-        final_cache_size = len(cache._cache)
-        assert final_cache_size <= initial_cache_size
+        assert removed == 1
+        assert list(cache._cache) == []
+
+    def test_repository_cache_invalidation_combines_all_keys_and_pattern(self):
+        """Test combined invalidation accounts for every requested method."""
+        cache = EphemeralCache(max_keys=10)
+        repo = MagicMock()
+        repo.cache_backend = cache
+        repo.repo_name = "test_repo"
+        repo.invalidate_cache = Repository.invalidate_cache.__get__(repo)
+
+        for key in [
+            "a||test_repo||1",
+            "b||test_repo||1",
+            "c_one||test_repo||1",
+            "other||test_repo||1",
+        ]:
+            cache.set(key, CacheEntry(key, key))
+
+        removed = repo.invalidate_cache(keys=["a", "b"], pattern="c*")
+
+        assert removed == 3
+        assert list(cache._cache) == ["other||test_repo||1"]
 
     def test_repository_cache_stats(self, tmp_path):
         """Test repository-level cache statistics."""


### PR DESCRIPTION
Closes #67

## Summary

- scope repository invalidation selectors to the existing method-first cache key layout
- process every exact key when `keys` and `pattern` are combined
- return accurate clear-all removal counts from EphemeralCache and RedisDFCache
- replace vacuous cache-management assertions with exact key and count checks

## Verification

- `MPLBACKEND=Agg .venv/bin/python -m pytest -m "not slow"` — 419 passed, 1 deselected
- `.venv/bin/python -m ruff check .` — passed
- `git diff --check` — passed
- stashed the `gitpandas/` source changes and ran the four focused regression cases — all four failed against the original implementation; restored the source and reran the targeted cache suites — 34 passed
