### PR TITLE
Fix per-repository default branch detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Unreleased
 
 ## Bug Fixes
 
+### Project Default Branch Detection
+ * **FIXED**: `ProjectDirectory` and `GitHubProfile` now let each repository auto-detect `main` or `master` by default, so mixed-branch projects include every repository in branch-based history metrics. Passing an explicit `default_branch` continues to force that branch across all repositories.
+
+**Note**: Repositories with neither a `main` nor `master` branch are now skipped with a warning during project initialization. Previously they were included but returned empty branch-based history.
+
 ### Cumulative Blame
  * **FIXED**: `Repository.cumulative_blame()` and `parallel_cumulative_blame()` no longer duplicate rows when multiple commits share a timestamp.
 

--- a/gitpandas/project.py
+++ b/gitpandas/project.py
@@ -62,7 +62,8 @@ class ProjectDirectory:
         verbose (bool, optional): Whether to print verbose output. Defaults to True.
         tmp_dir (Optional[str]): Directory to clone remote repositories into. Created if not provided.
         cache_backend (Optional[object]): Cache backend instance from gitpandas.cache
-        default_branch (str, optional): Name of the default branch to use. Defaults to 'main'.
+        default_branch (str, optional): Name of the branch to use for every repository. If None,
+            each repository auto-detects its default branch from `main` or `master`. Defaults to None.
 
     Attributes:
         repo_dirs (Union[set, list]): Set of repository directories or list of Repository instances
@@ -90,7 +91,7 @@ class ProjectDirectory:
         verbose=True,
         tmp_dir=None,
         cache_backend=None,
-        default_branch="main",
+        default_branch=None,
     ):
         """Initialize a ProjectDirectory instance.
 
@@ -103,7 +104,8 @@ class ProjectDirectory:
             verbose (bool, optional): Whether to print verbose output. Defaults to True.
             tmp_dir (Optional[str]): Directory to clone remote repositories into. Created if not provided.
             cache_backend (Optional[object]): Cache backend instance from gitpandas.cache
-            default_branch (str, optional): Name of the default branch to use. Defaults to 'main'.
+            default_branch (str, optional): Name of the branch to use for every repository. If None,
+                each repository auto-detects its default branch from `main` or `master`. Defaults to None.
         """
         logger.info(f"Initializing ProjectDirectory with working_dir={working_dir}, ignore_repos={ignore_repos}")
         # First get all potential repository paths
@@ -1542,6 +1544,8 @@ class GitHubProfile(ProjectDirectory):
             Defaults to False.
         ignore_repos (Optional[List[str]]): List of repository names to ignore
         verbose (bool, optional): Whether to print verbose output. Defaults to False.
+        default_branch (str, optional): Name of the branch to use for every repository. If None,
+            each repository auto-detects its default branch from `main` or `master`. Defaults to None.
 
     Note:
         This class uses the GitHub API to discover repositories. It does not require
@@ -1550,7 +1554,7 @@ class GitHubProfile(ProjectDirectory):
         rather than using incomplete results.
     """
 
-    def __init__(self, username, ignore_forks=False, ignore_repos=None, verbose=False):
+    def __init__(self, username, ignore_forks=False, ignore_repos=None, verbose=False, default_branch=None):
         """Initializes a GitHubProfile object.
 
         Args:
@@ -1559,6 +1563,8 @@ class GitHubProfile(ProjectDirectory):
                 Defaults to False.
             ignore_repos (Optional[List[str]]): List of repository names to ignore
             verbose (bool, optional): Whether to print verbose output. Defaults to False.
+            default_branch (str, optional): Name of the branch to use for every repository. If None,
+                each repository auto-detects its default branch from `main` or `master`. Defaults to None.
         """
         logger.info(f"Initializing GitHubProfile for user '{username}'.")
         # pull the git urls from github's api
@@ -1575,7 +1581,13 @@ class GitHubProfile(ProjectDirectory):
                 params = None
         except requests.exceptions.RequestException as e:
             logger.error(f"Failed to fetch GitHub repositories for user {username}: {e}")
-            ProjectDirectory.__init__(self, working_dir=[], ignore_repos=ignore_repos, verbose=verbose)
+            ProjectDirectory.__init__(
+                self,
+                working_dir=[],
+                ignore_repos=ignore_repos,
+                verbose=verbose,
+                default_branch=default_branch,
+            )
             return
 
         repos = []
@@ -1588,4 +1600,10 @@ class GitHubProfile(ProjectDirectory):
                 repos.append(chunk["git_url"])
 
         logger.info(f"Found {len(repos)} repositories for user '{username}' (ignore_forks={ignore_forks}).")
-        ProjectDirectory.__init__(self, working_dir=repos, ignore_repos=ignore_repos, verbose=verbose)
+        ProjectDirectory.__init__(
+            self,
+            working_dir=repos,
+            ignore_repos=ignore_repos,
+            verbose=verbose,
+            default_branch=default_branch,
+        )

--- a/tests/test_Project/test_default_branch_detection.py
+++ b/tests/test_Project/test_default_branch_detection.py
@@ -1,0 +1,57 @@
+import os
+import subprocess
+
+from gitpandas import ProjectDirectory
+
+
+def _build_repo(path, branch):
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+    }
+    subprocess.run(["git", "init", "-b", branch, path], check=True, env=env, capture_output=True)
+    subprocess.run(["git", "-C", path, "config", "user.name", "Test User"], check=True, env=env)
+    subprocess.run(["git", "-C", path, "config", "user.email", "test@example.com"], check=True, env=env)
+
+    file_path = path / "tracked.txt"
+    file_path.write_text(f"{branch}\n")
+    subprocess.run(["git", "-C", path, "add", "tracked.txt"], check=True, env=env)
+    subprocess.run(["git", "-C", path, "commit", "-m", f"{branch} commit"], check=True, env=env, capture_output=True)
+
+
+def test_auto_detects_each_repository_default_branch(tmp_path):
+    main_repo = tmp_path / "main-repo"
+    master_repo = tmp_path / "master-repo"
+    _build_repo(main_repo, "main")
+    _build_repo(master_repo, "master")
+
+    project = ProjectDirectory(working_dir=[str(main_repo), str(master_repo)])
+
+    assert {repo.repo_name: repo.default_branch for repo in project.repos} == {
+        "main-repo": "main",
+        "master-repo": "master",
+    }
+    assert project.commit_history()["repository"].value_counts().to_dict() == {
+        "main-repo": 1,
+        "master-repo": 1,
+    }
+    assert project.file_change_rates()["repository"].value_counts().to_dict() == {
+        "main-repo": 1,
+        "master-repo": 1,
+    }
+
+
+def test_explicit_default_branch_still_applies_to_every_repository(tmp_path):
+    main_repo = tmp_path / "main-repo"
+    master_repo = tmp_path / "master-repo"
+    _build_repo(main_repo, "main")
+    _build_repo(master_repo, "master")
+
+    project = ProjectDirectory(
+        working_dir=[str(main_repo), str(master_repo)],
+        default_branch="main",
+    )
+
+    assert [repo.default_branch for repo in project.repos] == ["main", "main"]
+    assert project.commit_history()["repository"].value_counts().to_dict() == {"main-repo": 1}

--- a/tests/test_Project/test_error_handling.py
+++ b/tests/test_Project/test_error_handling.py
@@ -375,7 +375,7 @@ class TestProjectErrorHandling:
         git.Repo.init(bare_repo_path, bare=True)
 
         # Should handle bare repositories appropriately
-        project = ProjectDirectory(working_dir=[str(bare_repo_path)])
+        project = ProjectDirectory(working_dir=[str(bare_repo_path)], default_branch="main")
 
         # Basic operations should work with bare repos
         is_bare = project.is_bare()

--- a/tests/test_Project/test_github_profile.py
+++ b/tests/test_Project/test_github_profile.py
@@ -41,6 +41,7 @@ def test_discovers_repositories_from_all_pages_in_api_order(mock_get, mock_proje
         ],
         ignore_repos=None,
         verbose=False,
+        default_branch=None,
     )
 
 
@@ -64,6 +65,7 @@ def test_ignore_forks_filters_every_page(mock_get, mock_project_init):
         ],
         ignore_repos=None,
         verbose=False,
+        default_branch=None,
     )
 
 
@@ -98,4 +100,22 @@ def test_later_page_failure_discards_partial_results(mock_get, mock_project_init
         working_dir=[],
         ignore_repos=None,
         verbose=False,
+        default_branch=None,
+    )
+
+
+@patch("gitpandas.project.ProjectDirectory.__init__", autospec=True)
+@patch("gitpandas.project.requests.get")
+def test_forwards_explicit_default_branch(mock_get, mock_project_init):
+    mock_get.return_value = _response([_repo("only")])
+
+    profile = GitHubProfile("example", default_branch="master")
+    profile.repos = []
+
+    mock_project_init.assert_called_once_with(
+        profile,
+        working_dir=["git://github.com/example/only.git"],
+        ignore_repos=None,
+        verbose=False,
+        default_branch="master",
     )


### PR DESCRIPTION
Closes #66

## Summary

- let `ProjectDirectory` auto-detect `main` or `master` independently for each repository by default
- add and forward `default_branch` through `GitHubProfile` on both successful discovery and API failure
- cover mixed `main`/`master` projects with exact per-repository commit-history and file-change-rate counts, while preserving explicit branch forcing
- document the intentional behavior change: repositories with neither `main` nor `master` are skipped with a warning during implicit detection

## Verification

- `MPLBACKEND=Agg .venv/bin/python -m pytest -m "not slow"` — 420 passed, 1 deselected
- `uv run ruff check .` — passed
- `git diff --check` — passed
- mutation check: stashed the `gitpandas/` source change while retaining the new mixed-branch test; `test_auto_detects_each_repository_default_branch` failed against the original `default_branch="main"` behavior and passed after restoration