### PR TITLE
Walk commit history in commits_in_tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Unreleased
 
 ## Bug Fixes
 
+### Commits In Tags History Walking
+ * **FIXED**: `Repository.commits_in_tags()` never walked history. It returned exactly one row per tag — the tagged commit — rather than attributing every commit to the release that shipped it, as documented. The backwards walk now runs, so each commit is attributed to the first tag that contains it, stopping at the previous tag, at the `start`/`end` bounds, or at a root commit. The walk uses an explicit worklist, so a release spanning more commits than the interpreter's recursion limit no longer raises `RecursionError`.
+ * **FIXED**: Tag lookup used positional `Series.__getitem__`, which emitted a pandas `FutureWarning` and would become a `KeyError` on a future pandas release.
+
+**Note**: This is a user-visible output change. `commits_in_tags()` — and `ProjectDirectory.commits_in_tags()`, which aggregates it — now return one row per commit instead of one row per tag. Code that counted rows to count releases needs updating; count distinct values of the `tag` column instead.
+
 ### Project Default Branch Detection
  * **FIXED**: `ProjectDirectory` and `GitHubProfile` now let each repository auto-detect `main` or `master` by default, so mixed-branch projects include every repository in branch-based history metrics. Passing an explicit `default_branch` continues to force that branch across all repositories.
 

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -1704,7 +1704,17 @@ class Repository:
 
             checked_commits.add(str(commit))
             logger.debug(f"Adding commit {commit.hexsha[:7]} for tag '{tag.name}'")
-            ds.append(self._commits_per_tags_helper(commit, df_tags, tag=tag))
+            commit_meta, tag = self._commits_per_tags_helper(commit, df_tags, tag=tag)
+            ds.append(commit_meta)
+            self._commits_per_tags_recursive(
+                commit=commit,
+                df_tags=df_tags,
+                ds=ds,
+                tag=tag,
+                checked_commits=checked_commits,
+                start=start,
+                end=end,
+            )
 
         if not ds:
             logger.info("No commits found within tags for the specified range.")
@@ -1727,48 +1737,54 @@ class Repository:
         start=None,
         end=None,
     ):
-        logger.debug(f"Recursive check for commit {commit.hexsha[:7]} under tag '{tag.name if tag else None}'")
         ds = ds if ds is not None else []
         checked_commits = checked_commits if checked_commits is not None else set()
 
-        for parent_commit in commit.parents:
-            before_start = start and parent_commit.committed_date < start
-            passed_end = end and parent_commit.committed_date > end
-            already_checked = str(parent_commit) in checked_commits
-            if before_start or passed_end or already_checked:
-                logger.debug(
-                    f"Skipping parent commit {parent_commit.hexsha[:7]}: BeforeStart={before_start}, PassedEnd={passed_end}, AlreadyChecked={already_checked}"  # noqa: E501
-                )
-                continue
-            checked_commits.add(str(parent_commit))
-            commit_meta, tag = self._commits_per_tags_helper(commit=parent_commit, df_tags=df_tags, tag=tag)
-            ds.append(commit_meta)
-            self._commits_per_tags_recursive(
-                commit=parent_commit,
-                df_tags=df_tags,
-                ds=ds,
-                tag=tag,
-                checked_commits=checked_commits,
-                start=start,
-                end=end,
+        # An explicit worklist rather than Python recursion: an unbroken stretch of commits
+        # between two tags is routinely longer than the interpreter's stack allows.
+        worklist = [(commit, tag)]
+        while worklist:
+            current_commit, current_tag = worklist.pop()
+            logger.debug(
+                f"Walking parents of commit {current_commit.hexsha[:7]} "
+                f"under tag '{current_tag.name if current_tag else None}'"
             )
+            # Reversed so the first parent is popped first, keeping the walk on the mainline.
+            for parent_commit in reversed(current_commit.parents):
+                before_start = start and parent_commit.committed_date < start
+                passed_end = end and parent_commit.committed_date > end
+                already_checked = str(parent_commit) in checked_commits
+                if before_start or passed_end or already_checked:
+                    logger.debug(
+                        f"Skipping parent commit {parent_commit.hexsha[:7]}: BeforeStart={before_start}, PassedEnd={passed_end}, AlreadyChecked={already_checked}"  # noqa: E501
+                    )
+                    continue
+                checked_commits.add(str(parent_commit))
+                commit_meta, parent_tag = self._commits_per_tags_helper(
+                    commit=parent_commit, df_tags=df_tags, tag=current_tag
+                )
+                ds.append(commit_meta)
+                worklist.append((parent_commit, parent_tag))
+
+        return ds
 
     def _commits_per_tags_helper(self, commit, df_tags, tag=None):
         tag_pd = df_tags.loc[
             (df_tags["commit_sha"].str.contains(str(commit))) | (df_tags["tag_sha"].str.contains(str(commit)))
         ].tag
         if not tag_pd.empty:
-            tag = self.repo.tag(tag_pd[0])
+            tag = self.repo.tag(tag_pd.iloc[0])
         tag_date = tag.tag.tagged_date if tag and tag.tag else commit.committed_date
         tag_date = pd.to_datetime(tag_date, unit="s", utc=True)
         commit_date = pd.to_datetime(commit.committed_date, unit="s", utc=True)
 
-        return {
+        commit_meta = {
             "commit_sha": str(commit),
             "tag": str(tag),
             "tag_date": tag_date,
             "commit_date": commit_date,
         }
+        return commit_meta, tag
 
     @multicache(key_prefix="tags", key_list=["skip_broken"])
     def tags(self, skip_broken=False):

--- a/tests/test_Repository/test_commits_in_tags.py
+++ b/tests/test_Repository/test_commits_in_tags.py
@@ -1,0 +1,176 @@
+import os
+import subprocess
+import warnings
+
+import pandas as pd
+import pytest
+
+from gitpandas import Repository
+from gitpandas.cache import EphemeralCache
+
+# Fixed epoch so tag/commit timestamps -- and therefore the start/end bounds -- are reproducible.
+BASE_EPOCH = 1600000000
+COMMIT_COUNT = 6
+TAGGED_COMMITS = {3: "v1.0", 6: "v2.0"}
+
+GIT_ENV = {
+    **os.environ,
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_SYSTEM": os.devnull,
+}
+
+
+def _epoch(commit_number):
+    return BASE_EPOCH + commit_number * 3600
+
+
+def _timestamp(epoch):
+    return pd.Timestamp(epoch, unit="s", tz="UTC")
+
+
+def _git(repo_path, *args, env=None):
+    subprocess.run(
+        ["git", "-C", str(repo_path), *args],
+        check=True,
+        capture_output=True,
+        env=env or GIT_ENV,
+    )
+
+
+@pytest.fixture
+def tagged_repo(tmp_path):
+    """Six commits with annotated tags on commits 3 and 6, at pinned timestamps."""
+    repo_path = tmp_path / "tagged-repo"
+    subprocess.run(
+        ["git", "init", "-b", "master", str(repo_path)],
+        check=True,
+        capture_output=True,
+        env=GIT_ENV,
+    )
+    _git(repo_path, "config", "user.name", "Tester")
+    _git(repo_path, "config", "user.email", "tester@example.com")
+
+    shas = {}
+    for number in range(1, COMMIT_COUNT + 1):
+        (repo_path / "work.txt").write_text(f"commit {number}\n")
+        _git(repo_path, "add", "work.txt")
+        stamped = {
+            **GIT_ENV,
+            "GIT_AUTHOR_DATE": f"{_epoch(number)} +0000",
+            "GIT_COMMITTER_DATE": f"{_epoch(number)} +0000",
+        }
+        _git(repo_path, "commit", "-m", f"commit {number}", env=stamped)
+        shas[number] = subprocess.run(
+            ["git", "-C", str(repo_path), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=GIT_ENV,
+        ).stdout.strip()
+        if number in TAGGED_COMMITS:
+            tag_name = TAGGED_COMMITS[number]
+            _git(repo_path, "tag", "-a", tag_name, "-m", tag_name, env=stamped)
+
+    return repo_path, shas
+
+
+@pytest.fixture(params=[False, True], ids=["uncached", "cached"])
+def repo(request, tagged_repo):
+    repo_path, shas = tagged_repo
+    cache_backend = EphemeralCache() if request.param else None
+    return Repository(working_dir=str(repo_path), default_branch="master", cache_backend=cache_backend), shas
+
+
+def _attribution(result):
+    return dict(zip(result["commit_sha"], result["tag"], strict=True))
+
+
+def test_every_commit_is_attributed_to_the_release_that_shipped_it(repo):
+    repository, shas = repo
+
+    result = repository.commits_in_tags(start=_timestamp(BASE_EPOCH))
+
+    expected = {shas[number]: ("v1.0" if number <= 3 else "v2.0") for number in shas}
+    assert _attribution(result) == expected
+
+
+def test_row_count_matches_commit_count_with_no_duplicates(repo):
+    repository, _ = repo
+
+    result = repository.commits_in_tags(start=_timestamp(BASE_EPOCH))
+
+    assert len(result) == COMMIT_COUNT
+    assert result["commit_sha"].is_unique
+
+
+def test_start_bound_prunes_commits_from_earlier_releases(repo):
+    repository, shas = repo
+
+    # Half way between the v1.0 commit and the first commit of the v2.0 release.
+    result = repository.commits_in_tags(start=_timestamp(_epoch(3) + 1800))
+
+    assert _attribution(result) == {shas[number]: "v2.0" for number in (4, 5, 6)}
+
+
+def test_end_bound_prunes_commits_from_later_releases(repo):
+    repository, shas = repo
+
+    result = repository.commits_in_tags(start=_timestamp(BASE_EPOCH), end=_timestamp(_epoch(3) + 1800))
+
+    assert _attribution(result) == {shas[number]: "v1.0" for number in (1, 2, 3)}
+
+
+def test_commits_in_tags_emits_no_future_warning(repo):
+    repository, _ = repo
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        repository.commits_in_tags(start=_timestamp(BASE_EPOCH))
+
+
+def test_walks_history_longer_than_the_python_recursion_limit(tmp_path):
+    """A tag whose release spans thousands of commits must not exhaust the interpreter stack."""
+    commit_count = 1200
+    repo_path = tmp_path / "deep-repo"
+    subprocess.run(
+        ["git", "init", "-b", "master", str(repo_path)],
+        check=True,
+        capture_output=True,
+        env=GIT_ENV,
+    )
+
+    stream = []
+    for number in range(1, commit_count + 1):
+        message = f"commit {number}"
+        body = str(number)
+        stream += [
+            "commit refs/heads/master",
+            f"mark :{number}",
+            f"committer Tester <tester@example.com> {_epoch(number)} +0000",
+            f"data {len(message)}",
+            message,
+        ]
+        if number > 1:
+            stream.append(f"from :{number - 1}")
+        stream += ["M 644 inline work.txt", f"data {len(body)}", body]
+    stream += [
+        "tag v1.0",
+        f"from :{commit_count}",
+        f"tagger Tester <tester@example.com> {_epoch(commit_count)} +0000",
+        "data 4",
+        "v1.0",
+    ]
+    subprocess.run(
+        ["git", "-C", str(repo_path), "fast-import", "--quiet"],
+        input="\n".join(stream).encode(),
+        check=True,
+        capture_output=True,
+        env=GIT_ENV,
+    )
+    _git(repo_path, "reset", "--hard", "master")
+
+    repository = Repository(working_dir=str(repo_path), default_branch="master")
+    result = repository.commits_in_tags(start=_timestamp(BASE_EPOCH))
+
+    assert len(result) == commit_count
+    assert set(result["tag"]) == {"v1.0"}


### PR DESCRIPTION
Closes #68

`Repository.commits_in_tags` documents itself as tracing backwards from each tag "until hitting another tag, reaching the time limit, or hitting the root commit", and its `Returns` block promises one row per commit. It never traced anything: the loop called `_commits_per_tags_helper` once per tagged commit and never invoked the walker, so the result had exactly one row per in-range tag.

The walker `_commits_per_tags_recursive` existed but could not run — it unpacked a two-tuple from `_commits_per_tags_helper`, which returned a dict, so any call raised `ValueError: too many values to unpack (expected 2)`. All the supporting machinery already in `commits_in_tags` (the `checked_commits` set, the `start`/`end` unix-time bounds, the `before_start`/`passed_end` guards) only makes sense for a history walk.

## What changed

`gitpandas/repository.py`:

1. `_commits_per_tags_helper` now returns `(commit_meta, tag)`; both call sites updated.
2. `commits_in_tags` runs the walk after recording each tagged commit, threading the existing `ds`, `checked_commits`, `start` and `end`, so the walk stops at the previous tag, at a time bound, or at a root commit. Tags are already processed oldest-first, so each commit is claimed by the first release that contains it.
3. `_commits_per_tags_recursive` uses an **explicit worklist** instead of Python recursion. Recursing once per parent exhausts the interpreter stack on an ordinary linear history — measured below. The signature and semantics are unchanged; the name is kept since it is a private method and renaming would widen the diff. Parents are pushed in reverse so the first parent is popped first, keeping the walk on the mainline as the recursive version did.
4. Tag lookup uses `tag_pd.iloc[0]` rather than positional `tag_pd[0]`. That Series carries the tags frame's `(tag_date, commit_date)` MultiIndex, so the positional form emitted `FutureWarning: Series.__getitem__ treating keys as positions is deprecated` and would become a `KeyError` on a future pandas. No test reached that branch, so it never showed in the suite's warning summary.

One small behaviour note: within the walker, the tag returned by the helper is now bound to a local (`parent_tag`) and threaded only into that parent's own subtree, rather than being reassigned onto the loop variable. On a merge commit the old form would have leaked a tag discovered on the first parent onto the second parent's walk.

`CHANGELOG.md`: a new `### Commits In Tags History Walking` section under `Unreleased`, with an explicit note that this is a user-visible output change.

## User-visible impact

`commits_in_tags()` now returns **one row per commit** instead of one row per tag, and `ProjectDirectory.commits_in_tags()` inherits that. Anything counting rows to count releases needs to count distinct `tag` values instead. This is the method's documented and named behaviour, but it warrants a minor release rather than a patch.

## Verification

Environment: `uv venv`, `uv pip install -e ".[dev]"`.

**The bug, on a pinned 6-commit fixture** (annotated tags at commits 3 and 6, explicit early `start` so the default ~6-month window isn't what's pruning):

| | rows | attribution |
|---|---|---|
| before | 2 | the two tagged commits only |
| after | 6 | commits 1-3 -> `v1.0`, 4-6 -> `v2.0` |

Calling the walker directly before the change: `ValueError: too many values to unpack (expected 2)`. After: it runs.

**Recursion depth.** On a synthetic 1200-commit linear history with a single tag at the tip, the recursive form raised `RecursionError: maximum recursion depth exceeded`. With the worklist it returns all 1200 rows. This is why the conversion is in this PR rather than deferred — 1200 commits between tags is an unremarkable repo, and `commits_in_tags` is a library method run against arbitrary repositories.

**New tests** — `tests/test_Repository/test_commits_in_tags.py`, 11 tests, each of the first five parametrized cached/uncached per the repo convention:

- exact `commit_sha -> tag` mapping for all six commits (this is the test that carries the behaviour — a row-count assertion alone would pass on a walk that attributed everything to the wrong release)
- row count equals commit count, and `commit_sha` is unique, so no commit is attributed twice
- a `start` after the `v1.0` commit yields only the three `v2.0` commits
- an `end` before the `v2.0` commits yields only the three `v1.0` commits
- `commits_in_tags` raises nothing under `warnings.simplefilter("error", FutureWarning)`
- a 1200-commit release completes and returns 1200 rows (built with `git fast-import`, ~0.07s, so it runs in the default suite rather than needing a `slow` marker)

**Non-vacuity.** With `git stash push gitpandas/` (the new test file is untracked and survives the stash), **all 11 fail**; restored, all 11 pass. The recursion-depth test additionally fails against the recursive implementation specifically, so it guards the worklist conversion rather than the walk being wired up at all.

**`ProjectDirectory` aggregation**, checked on a two-repo fixture (6 commits/2 tags and 4 commits/2 tags): 10 rows, index `['tag_date', 'commit_date']`, columns `['commit_sha', 'tag', 'repository']`, grouping `r1/v1.0=3, r1/v2.0=3, r2/a1.0=2, r2/a2.0=2`, equal to the sum of the per-repo calls. The empty-frame shape in `tests/test_Project/test_commits_in_tags.py` is untouched and passes.

**Full gate:**

- `MPLBACKEND=Agg pytest -m "not slow"` -> `433 passed, 1 deselected` (was 422 before the 11 new tests)
- `ruff check .` -> `All checks passed!`

`ruff format --check` reports `gitpandas/repository.py` as unformatted at line 688, in `file_change_history`. That is pre-existing — it reproduces with this branch's changes stashed — and it is outside this diff; CI runs `ruff check`, not `ruff format --check`, so it is not a gate. Left alone rather than absorbed here.

The pre-existing `DeprecationWarning` from `pd.Timedelta("1s")` at `repository.py:1687` is still emitted; it belongs with the standing deprecation-warning issue, not this one.