### PR TITLE
[autopilot] release v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,37 @@
 Unreleased
 ==========
 
+v2.5.0
+======
+
+## New Features
+
+### Remote Operations & Cache Warming
+ * **NEW**: `Repository.safe_fetch_remote()` - Safely fetch changes from remote repositories without modifying working directory
+   - Read-only operation with comprehensive error handling
+   - Support for dry-run preview and remote validation
+   - Configurable remote names and pruning options
+ * **NEW**: `Repository.warm_cache()` - Pre-populate repository cache for improved performance
+   - Configurable method selection with intelligent parameter handling
+   - Performance metrics and cache entry tracking
+   - Significant performance improvements (1.5-10x speedup demonstrated)
+ * **NEW**: `ProjectDirectory.bulk_fetch_and_warm()` - Efficiently process multiple repositories
+   - Parallel processing support when joblib is available
+   - Error isolation (failures in one repo don't affect others)
+   - Comprehensive summary statistics and progress tracking
+
+### Enhanced Caching System
+ * **NEW**: `CacheEntry` class with metadata tracking (timestamps, age calculation)
+ * **ENHANCED**: Thread-safe cache operations with proper locking mechanisms
+ * **ENHANCED**: Cache key consistency improvements using `||` delimiter format
+ * **ENHANCED**: Cache timestamp and metadata access methods (`get_cache_info()`, `list_cached_keys()`)
+
+### Documentation & Examples
+ * **NEW**: Comprehensive remote operations documentation (`docs/source/remote_operations.rst`)
+ * **NEW**: Cache warming and remote fetch example (`examples/remote_fetch_and_cache_warming.py`)
+ * **NEW**: Cache timestamp usage example (`examples/cache_timestamps.py`)
+ * **NEW**: Release analytics example (`examples/release_analytics.py`)
+
 ## Bug Fixes
 
 ### Commits In Tags History Walking
@@ -49,6 +80,23 @@ Unreleased
  * **FIXED**: `Repository.cumulative_blame()` reshaped the `revs()` frame it received in place — adding a column per committer, deleting `rev`, and replacing the index with the commit dates. Because a cache backend hands out the stored DataFrame by reference, a later `revs()` call returned that wrecked frame, and a *second* `cumulative_blame()` call raised `ValueError: Internal Error: self.revs() returned DataFrame without 'rev' column.` (`parallel_cumulative_blame()` swallowed the same failure and returned an empty DataFrame). It now works on a copy.
  * **FIXED**: `ProjectDirectory.cumulative_blame()` renamed each member repository's cached `cumulative_blame()` columns in place while suffixing them with the repository name, so a later per-repository call returned `Alice__repo1` instead of `Alice`. The suffixing now happens on copies.
 
+### Project Bus Factor Glob Filtering
+ * **FIXED**: `ProjectDirectory.bus_factor(by="repository")` passed the caller's `include_globs` into each repository's `ignore_globs` argument. The caller's `ignore_globs` was silently discarded and `include_globs` doubled as an exclusion list, so the bus factor was computed over the wrong set of files — typically excluding exactly the files the caller asked to include. (`by="file"` was already correct.)
+
+### Project Empty-Result Guards
+ * **FIXED**: `ProjectDirectory.blame()` and `file_detail()` raised `AttributeError: 'NoneType' object has no attribute 'reset_index'` when the project contained no repositories, or when every repository raised `GitCommandError` (repositories with no commits, or a branch that doesn't exist). Both now return a well-formed empty DataFrame matching their normal output shape, as sibling methods such as `file_change_history()` already did.
+ * **FIXED**: `ProjectDirectory.commits_in_tags()` raised `ValueError: No objects to concatenate` when no repository yielded tagged commits. It now returns an empty DataFrame carrying the usual `commit_sha`, `tag`, and `repository` columns and the `(tag_date, commit_date)` index.
+
+### Punchcard Cache Mutation
+ * **FIXED**: `Repository.punchcard()` wrote `day_of_week` and `hour_of_day` columns straight into the `commit_history()` frame it was handed. Because a cache backend returns the stored DataFrame *by reference*, every later `commit_history()` call then returned those two extra columns. The same in-place write affected `ProjectDirectory.commit_history()`, `file_detail()`, and `revs()`, which added a `repository` column to borrowed per-repository frames. All of these now copy before writing.
+
+### Cache Warming
+ * **FIXED**: `Repository.warm_cache()` silently substituted `limit=100` for `commit_history` and `file_change_rates`, so it populated a cache key that no ordinary call would ever hit — the default `warm_cache()` gave those two methods no speedup whatsoever. The injected limit is gone, so warming populates the keys callers actually use.
+ * **FIXED**: `hours_estimate()`, `punchcard()`, `cumulative_blame()`, and `parallel_cumulative_blame()` resolved `branch=None` to the default branch *before* delegating to `commit_history()`/`revs()`. The inner call therefore keyed on `"master"` while a user's own `commit_history()` keyed on `None`, storing several copies of the same history and defeating cache reuse between them. The caller's `branch` value is now passed through unchanged; resolution happens only where a branch name is genuinely needed.
+
+### Cached Method Introspection
+ * **FIXED**: `@multicache` returned a bare wrapper, so every decorated `Repository` method lost its name, docstring, and signature. `help()`, `inspect.signature()`, and any reflection over the API saw `(self, *args, **kwargs)`. The decorator now applies `functools.wraps`, which restores introspection and — because the MCP server generates its tool schemas by reflecting over `Repository` — restores the real parameter names and defaults in every MCP tool schema.
+
 ### Cache Correctness
  * **FIXED**: `Repository.invalidate_cache()` now targets the method-first cache key layout, processes every key when combined with a pattern, and returns accurate removal counts for in-memory and Redis backends.
  * **FIXED**: `@multicache` built cache keys from `kwargs` only, so any argument passed *positionally* was invisible to the key and collapsed to `None`. Keys are now resolved against the decorated method's signature (`inspect.signature().bind()` + `apply_defaults()`), so positional and keyword calls key identically. This fixes:
@@ -61,48 +109,23 @@ Unreleased
 
 **Note**: The cache key format has changed. Stale `EphemeralCache`/`DiskCache` entries simply miss and recompute, but `RedisDFCache` users sharing a cache across versions should flush it (or use a new key prefix) to avoid retaining entries under the old format.
 
-v2.5.0
-======
-
-## New Features
-
-### Remote Operations & Cache Warming
- * **NEW**: `Repository.safe_fetch_remote()` - Safely fetch changes from remote repositories without modifying working directory
-   - Read-only operation with comprehensive error handling
-   - Support for dry-run preview and remote validation
-   - Configurable remote names and pruning options
- * **NEW**: `Repository.warm_cache()` - Pre-populate repository cache for improved performance  
-   - Configurable method selection with intelligent parameter handling
-   - Performance metrics and cache entry tracking
-   - Significant performance improvements (1.5-10x speedup demonstrated)
- * **NEW**: `ProjectDirectory.bulk_fetch_and_warm()` - Efficiently process multiple repositories
-   - Parallel processing support when joblib is available
-   - Error isolation (failures in one repo don't affect others)
-   - Comprehensive summary statistics and progress tracking
-
-### Enhanced Caching System
- * **NEW**: `CacheEntry` class with metadata tracking (timestamps, age calculation)
- * **ENHANCED**: Thread-safe cache operations with proper locking mechanisms  
- * **ENHANCED**: Cache key consistency improvements using `||` delimiter format
- * **ENHANCED**: Cache timestamp and metadata access methods (`get_cache_info()`, `list_cached_keys()`)
-
-### Documentation & Examples
- * **NEW**: Comprehensive remote operations documentation (`docs/source/remote_operations.rst`)
- * **NEW**: Cache warming and remote fetch example (`examples/remote_fetch_and_cache_warming.py`)
- * **NEW**: Cache timestamp usage example (`examples/cache_timestamps.py`)
- * **NEW**: Release analytics example (`examples/release_analytics.py`)
-
 ## Testing & Quality
  * **NEW**: 38 comprehensive tests for remote operations and cache warming
  * **NEW**: Thread safety tests for cache operations
  * **NEW**: Edge case and error handling test coverage
+ * **NEW**: Regression coverage for every fix above, including cached-vs-uncached parity, multi-repository aggregation against repositories that share file paths, and cache-immutability checks that fail if a method writes into a frame it was handed
+ * **NEW**: Exact rev-to-rev regression tests pinning churn, file, elapsed-time, author, and committer values, and covering `include_globs`/`ignore_globs` through `release_tag_summary()`
  * **IMPROVED**: Overall test coverage and reliability
  * **FIXED**: Various minor bugs and future warnings
 
 ## Backward Compatibility
- * All new features are fully backward compatible
- * No breaking changes to existing APIs
- * Existing cache backends work seamlessly with new features
+ * No API was removed, renamed, or given a new required argument; every existing call still runs.
+ * Three changes are user-visible in the *data* returned, and are called out in full above:
+   - `commits_in_tags()` now returns one row per commit rather than one row per tag.
+   - `blame(by="file")` on a `ProjectDirectory` gains a `repository` index level.
+   - The cache key format changed; `RedisDFCache` users sharing a cache across versions should flush it.
+ * Beyond those, results change only where they were previously wrong — the bug fixes above return corrected numbers for churn, hours, ownership, bus factor, and blame. Analyses pinned to specific values from an earlier release should expect them to move.
+ * Existing cache backends work seamlessly with new features.
 
 v2.4.0
 ======

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Git-Pandas is a powerful Python library that transforms Git repository data into
 - **🌐 Remote Operations**: Safe remote fetching and bulk operations
 - **⚡ Performance Guide**: Comprehensive optimization documentation
 - **💾 Enhanced Caching**: Disk-based caching and timestamp tracking
+- **🎯 Correctness**: A large batch of fixes across the caching and multi-repository
+  aggregation layers. Several metrics — file churn, hours estimates, file ownership,
+  bus factor, and multi-repository blame — returned wrong numbers under conditions
+  described in the [changelog](CHANGELOG.md). Note that `commits_in_tags()` now returns
+  one row per commit rather than one per tag, and `ProjectDirectory.blame(by="file")`
+  gains a `repository` index level.
 
 ## Why Git-Pandas?
 
@@ -327,6 +333,6 @@ This project is BSD licensed (see [LICENSE.md](LICENSE.md))
 
 ## Version History
 
-- **v2.5.0** (2025): File-wise bus factor, cache management, remote operations, performance guide
+- **v2.5.0** (2026): File-wise bus factor, cache management, remote operations, performance guide, and a large correctness batch across caching and multi-repository aggregation
 - **v2.4.0** (2024): Enhanced caching system with timestamps
 - **v2.2.1** (2023): Stability improvements and bug fixes


### PR DESCRIPTION
Release prep for **v2.5.0**. No source changes — `CHANGELOG.md` and `README.md` only.

## Why this version number

`pyproject.toml`, `docs/source/conf.py`, and the README **already read 2.5.0**, but `v2.5.0` was never tagged — the latest tag is `v2.4.0`. So this closes out the existing 2.5.0 rather than bumping to 2.6.0; no version bump was needed anywhere.

> ⚠️ **PyPI is at 2.3.0.** A GitHub Release for `v2.4.0` exists (2025-05-13) but no `2.4.0` artifact ever reached PyPI, so the publish workflow did not complete. The run logs have aged out, so there is nothing left to diagnose. **Please confirm the publish job actually succeeds this time** — for users installing from PyPI, this release delivers v2.4.0's content as well.

## Why now

The release policy is that any user-visible bugfix warrants a release. 26 PRs merged since `v2.4.0`, and the overwhelming majority are correctness fixes in the caching and multi-repository aggregation layers — bugs that return *wrong numbers*, not just slow ones.

Minor, not patch: the release includes genuinely new API (`safe_fetch_remote()`, `warm_cache()`, `bulk_fetch_and_warm()`) plus backwards-compatible behaviour changes. No API was removed or renamed, so it is not a major.

## What changed in this PR

- Folded the `Unreleased` bug-fix batch into the `v2.5.0` section; opened a fresh empty `Unreleased` above it.
- Reordered `v2.5.0` into the repo's documented section order (New Features → Bug Fixes → Testing & Quality → Backward Compatibility).
- **Added changelog entries for six merged fixes that never got one** — #31, #33, #43, #45, #49, #50. Each was verified against its actual diff, not its PR title.
- **Corrected the `Backward Compatibility` section**, which still claimed "No breaking changes to existing APIs" and "All new features are fully backward compatible". That is no longer accurate: this release changes `commits_in_tags()` output shape, adds an index level to `ProjectDirectory.blame(by="file")`, and changes the cache key format.
- Refreshed the README's "What's New in v2.5.0" (policy calls for this on a minor) and its Version History line.

## Verification

- `MPLBACKEND=Agg pytest -m "not slow"` → **433 passed, 1 deselected**
- `ruff check .` → **All checks passed**
- `python -m build --sdist` → `git_pandas-2.5.0.tar.gz`; installed into a clean venv from the tarball and `import gitpandas` from outside the source tree reports `__version__ = 2.5.0`

---

# Release notes — v2.5.0

## New Features

- **Remote operations & cache warming**: `Repository.safe_fetch_remote()` (read-only, dry-run capable), `Repository.warm_cache()`, and `ProjectDirectory.bulk_fetch_and_warm()` (parallel via joblib, with per-repo error isolation).
- **Enhanced caching**: `CacheEntry` metadata with timestamps and age, thread-safe cache operations, and `get_cache_info()` / `list_cached_keys()`.
- **Docs & examples**: remote operations guide, plus cache-warming, cache-timestamp, and release-analytics examples.

## Bug Fixes

A large correctness batch. Highlights — full detail in `CHANGELOG.md`:

- **`commits_in_tags()` never walked history**, returning one row per tag instead of attributing each commit to the release that shipped it. The walk now runs, using an explicit worklist so long releases no longer raise `RecursionError`.
- **`ProjectDirectory` forced `default_branch="main"`** onto every member repository, so master-only repos silently returned empty history frames. Each repository now auto-detects.
- **`file_change_history()` reported all-zero churn**, which propagated into `file_change_rates()`.
- **`file_owner()` ignored the `committer` flag**, reporting the committer under a column labelled `author` — also affecting `file_detail()` on both classes.
- **`hours_estimate()` omitted the first-commit allowance**, giving single-commit contributors an estimate of zero.
- **`ProjectDirectory.blame()` discarded committer/author identity** when concatenating repositories, inflating project bus factor; `blame(by="file")` additionally merged same-named files across repositories.
- **`bus_factor(by="repository")` dropped the caller's `ignore_globs`**, passing `include_globs` in its place.
- **Cache keys ignored positionally-passed arguments** and `blame`'s key list misspelled `ignore_globs`, so cached and uncached calls could disagree. A master-only repo was unconstructible with a cache backend.
- **Several methods mutated cached DataFrames in place** (`punchcard`, `cumulative_blame`, and three `ProjectDirectory` sites), corrupting later reads of the same cached frame.
- **`warm_cache()` injected `limit=100`**, warming keys no ordinary call would hit — the default `warm_cache()` gave `commit_history` no speedup at all.
- **Crash guards**: `ProjectDirectory.blame()`, `file_detail()`, `commits_in_tags()`, and `punchcard()` now return well-formed empty frames instead of raising when no repository yields data.
- **MCP serialization** dropped index-carried identity and mutated the frame it was given.
- **`GitHubProfile`** now follows API pagination instead of seeing only the first 30 repositories.

## Upgrade notes

No API was removed, renamed, or given a new required argument. Three changes are visible in returned data:

- `commits_in_tags()` returns **one row per commit**, not per tag. Count distinct values of the `tag` column to count releases.
- `ProjectDirectory.blame(by="file")` gains a `repository` index level → `(committer|author, file, repository)`.
- **The cache key format changed.** `EphemeralCache`/`DiskCache` entries simply miss and recompute, but **`RedisDFCache` users sharing a cache across versions should flush it** or use a new key prefix.

Beyond those, results change only where they were previously wrong. Analyses pinned to specific numbers from an earlier release should expect them to move.

---

## Post-merge steps

```
git checkout master && git pull
git tag -a v2.5.0 -m "v2.5.0" && git push origin v2.5.0
```

Then **create a GitHub Release on the `v2.5.0` tag** — a bare tag push publishes nothing. `.github/workflows/pypi-publish.yml` triggers on `release: created`, builds an **sdist only** (`python -m build --sdist`), and uploads via PyPI **trusted publishing** (`id-token: write`, no API token):

```
gh release create v2.5.0 --title "v2.5.0" --notes-file <notes>
```

Verify the publish landed — this is the step that silently failed for v2.4.0:

```
gh run list --repo wdm0006/git-pandas --workflow pypi-publish.yml --limit 3
curl -s https://pypi.org/pypi/git-pandas/json | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])"
```

Since only an sdist is uploaded, installs build from source — sanity-check from outside the source tree:

```
python -m venv /tmp/gp && /tmp/gp/bin/pip install git-pandas==2.5.0
cd /tmp && /tmp/gp/bin/python -c "import gitpandas; print(gitpandas.__version__)"
```

## Downstream

**None.** No other repo in the portfolio depends on `git-pandas`; no follow-up version bumps are needed after this tag lands.

## Noted, not touched

- PR #62 ("Fix punchcard KeyError when no repo yields data") is still open and appears to overlap the empty-punchcard fix already merged as #63. Worth closing or rebasing, but it is out of scope here and is not part of this release.
- The README's Version History dates `v2.4.0` as 2024; it was tagged 2025-05-13. Left alone to keep this diff to the release.