### PR TITLE
Make redis and coverage optional extras, and stop coverage() swallowing a missing dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Unreleased
 ==========
 
+## Bug Fixes
+
+### Optional Redis & Coverage Dependencies
+ * **CHANGED** (user-visible): `redis` and `coverage` are no longer installed by `pip install git-pandas`. Neither is used by the core library — `redis` is imported behind a guard in `gitpandas.cache` and `coverage` is imported lazily inside `Repository.coverage()` — so a plain install no longer pulls in a Redis client and a test-coverage tool. They are now optional extras: install `git-pandas[redis]` to use `RedisDFCache`, and `git-pandas[coverage]` to use `Repository.coverage()` / `Repository.file_change_rates(coverage=True)`. Both are included in the `all` and `dev` extras. **Anyone relying on `RedisDFCache` after a bare `pip install git-pandas` must now install `git-pandas[redis]`**; the failure mode is the existing explicit `ImportError("Need redis installed to use redis cache")`.
+ * **FIXED**: `Repository.coverage()` swallowed a missing `coverage` package. The `import coverage` sat inside a `try` whose final handler is a broad `except Exception`, so on a repository that *does* have a `.coverage` file the result was an empty DataFrame — indistinguishable from "no coverage data". The import now happens outside that block and raises an `ImportError` naming the `git-pandas[coverage]` extra. `Repository.file_change_rates(coverage=True)` re-raises it rather than returning an empty frame. Genuine "no coverage data" cases still return the empty DataFrame as before.
+
 v2.5.0
 ======
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,10 @@ For enhanced functionality, install additional packages:
 pip install joblib
 
 # For Redis caching
-pip install redis
+pip install "git-pandas[redis]"
+
+# For Repository.coverage() / .coverage file parsing
+pip install "git-pandas[coverage]"
 
 # For visualization
 pip install matplotlib seaborn

--- a/docs/source/cache.rst
+++ b/docs/source/cache.rst
@@ -56,7 +56,8 @@ For persistent caching that survives between sessions:
 Redis Cache (RedisDFCache)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For persistent caching across sessions, use Redis:
+For persistent caching across sessions, use Redis. The Redis client is an optional
+dependency, installed with ``pip install "git-pandas[redis]"``:
 
 .. code-block:: python
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,9 @@ Install Git-Pandas using pip:
 
     pip install git-pandas
 
+Optional features live in extras: ``pip install "git-pandas[redis]"`` for the Redis cache
+backend and ``pip install "git-pandas[coverage]"`` for ``Repository.coverage()``.
+
 Basic Usage
 ~~~~~~~~~~~
 

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -229,13 +229,23 @@ class Repository:
 
         Note:
             Returns an empty DataFrame if no coverage data exists or can't be read.
+
+        Raises:
+            ImportError: If the optional ``coverage`` package is not installed but the
+                repository does have a ``.coverage`` file to parse.
         """
         if not self.has_coverage():
             return DataFrame(columns=["filename", "lines_covered", "total_lines", "coverage"])
 
         try:
             import coverage
+        except ImportError as e:
+            raise ImportError(
+                "Need coverage installed to parse .coverage files. "
+                'Install it with: pip install "git-pandas[coverage]"'
+            ) from e
 
+        try:
             cov = coverage.Coverage(data_file=os.path.join(self.git_dir, ".coverage"))
             cov.load()
             data = cov.get_data()
@@ -976,6 +986,10 @@ class Repository:
                     "repository",
                 ]
             )
+        except ImportError:
+            # coverage=True with the optional coverage package missing: surface it rather than
+            # returning an empty frame that reads as "no coverage data".
+            raise
         except Exception as e:
             logger.error(f"Unexpected error calculating file change rates: {e}", exc_info=True)
             return pd.DataFrame(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,6 @@ dependencies = [
     "numpy>=1.9.0",
     "pandas>=2.0.0,<3.0.0",
     "requests",
-    "redis",
-    "coverage>=5.0.0",
     "importlib-metadata>=1.0; python_version<'3.8'",
 ]
 
@@ -39,6 +37,12 @@ examples = [
     "matplotlib",
     "lifelines",
 ]
+redis = [
+    "redis",
+]
+coverage = [
+    "coverage>=5.0.0",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
@@ -46,11 +50,15 @@ dev = [
     "ruff>=0.1.0",
     "matplotlib",
     "joblib",
-    "pytest-mock"
+    "pytest-mock",
+    "redis",
+    "coverage>=5.0.0",
 ]
 all = [
     "matplotlib",
     "lifelines",
+    "redis",
+    "coverage>=5.0.0",
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "sphinx>=7.0.0",

--- a/tests/test_Repository/test_error_handling.py
+++ b/tests/test_Repository/test_error_handling.py
@@ -1,3 +1,4 @@
+import sys
 from unittest.mock import Mock, patch
 
 import git
@@ -51,6 +52,10 @@ class TestRepositoryErrorHandling:
         coverage_file = temp_repo / ".coverage"
         coverage_file.write_text("test coverage data")
 
+        # Import coverage up front so the patched os.path.join below only affects the
+        # data-file path join, not the coverage package's own import machinery.
+        import coverage  # noqa: F401
+
         # Since the coverage handling is built-in to repository.py, test by creating
         # a file that exists but simulating permission error via OS error
         with patch("os.path.join") as mock_join:
@@ -94,6 +99,44 @@ class TestRepositoryErrorHandling:
 
             assert isinstance(coverage_df, pd.DataFrame)
             assert coverage_df.empty
+
+    def test_coverage_missing_coverage_package(self, temp_repo, default_branch):
+        """A missing coverage package must surface, not look like 'no coverage data'."""
+        repo = Repository(working_dir=str(temp_repo), default_branch=default_branch)
+
+        coverage_file = temp_repo / ".coverage"
+        coverage_file.write_text("test coverage data")
+        assert repo.has_coverage()
+
+        # A None entry in sys.modules makes `import coverage` raise ImportError,
+        # simulating an install without the git-pandas[coverage] extra.
+        with patch.dict(sys.modules, {"coverage": None}), pytest.raises(ImportError) as excinfo:
+            repo.coverage()
+
+        assert "git-pandas[coverage]" in str(excinfo.value)
+
+    def test_coverage_missing_package_without_coverage_file(self, temp_repo, default_branch):
+        """Without a .coverage file the empty-frame result is kept, package present or not."""
+        repo = Repository(working_dir=str(temp_repo), default_branch=default_branch)
+
+        with patch.dict(sys.modules, {"coverage": None}):
+            coverage_df = repo.coverage()
+
+        assert isinstance(coverage_df, pd.DataFrame)
+        assert coverage_df.empty
+        assert list(coverage_df.columns) == ["filename", "lines_covered", "total_lines", "coverage"]
+
+    def test_file_change_rates_missing_coverage_package(self, temp_repo, default_branch):
+        """file_change_rates(coverage=True) must not swallow the missing-extra error."""
+        repo = Repository(working_dir=str(temp_repo), default_branch=default_branch)
+
+        coverage_file = temp_repo / ".coverage"
+        coverage_file.write_text("test coverage data")
+
+        with patch.dict(sys.modules, {"coverage": None}), pytest.raises(ImportError) as excinfo:
+            repo.file_change_rates(branch=default_branch, coverage=True)
+
+        assert "git-pandas[coverage]" in str(excinfo.value)
 
     def test_file_change_history_git_errors(self, temp_repo, default_branch):
         """Test file_change_history when Git commands fail."""


### PR DESCRIPTION
Closes #77

## What changed

**`pyproject.toml`** — `redis` and `coverage>=5.0.0` are no longer hard runtime dependencies. Neither is used by the core library: `redis` is imported behind a guard in `gitpandas/cache.py` (`RedisDFCache.__init__` already raises `ImportError("Need redis installed to use redis cache")`), and `coverage` is imported lazily inside `Repository.coverage()`. Nothing else in the package references either. They are now `redis` and `coverage` optional-dependency groups, and both are included in the existing `all` and `dev` groups so contributors and CI keep the current behaviour unchanged.

**`gitpandas/repository.py`** — `import coverage` moves out of the broad `try` in `Repository.coverage()` whose final handler is `except Exception` returning an empty DataFrame. With the package absent, a repository that genuinely *has* a `.coverage` file returned `(0, 4)` — indistinguishable from "no coverage data". It now raises an `ImportError` naming the `git-pandas[coverage]` extra. The empty-frame return is kept for every genuine "no coverage data" case (no `.coverage` file, unparseable file, permission errors, no measured files).

`Repository.file_change_rates(coverage=True)` is the only other path that reaches `coverage()`, and its own broad `except Exception` would have re-swallowed the new error, so it re-raises `ImportError` ahead of the generic handler. Slightly beyond the issue's sketch, but leaving it would have meant the fix was invisible on one of the two entry points.

**Docs** — install extras noted in `docs/source/index.rst` and the Redis section of `docs/source/cache.rst`; the README's optional-dependencies block now says `pip install "git-pandas[redis]"` rather than `pip install redis`.

**`CHANGELOG.md`** — own area heading under `Unreleased`, flagged user-visible.

### User-visible impact

A user who today does `pip install git-pandas` and then uses `RedisDFCache` will, after upgrading, need `git-pandas[redis]`. The failure mode is the existing explicit `ImportError`, not a crash. Same for `Repository.coverage()` and `git-pandas[coverage]`.

## Verification

**Full local gate** (`.venv` from `uv venv` + `uv pip install -e ".[dev]"`):
- `MPLBACKEND=Agg pytest -m "not slow"` → **436 passed, 1 deselected** (433 before, +3 new tests), including the redis-marked tests.
- `ruff check .` → `All checks passed!`

**Bare venv, no extras** (`uv venv` + `uv pip install "<checkout>"`, run from `/tmp` so the working tree can't satisfy imports):

```
gitpandas 2.5.0 from /tmp/gp_bare/lib/python3.12/site-packages/gitpandas/__init__.py
IMPORT redis: absent (No module named 'redis')
IMPORT coverage: absent (No module named 'coverage')
RedisDFCache(): ImportError(Need redis installed to use redis cache)
has_coverage: True
coverage() -> ImportError(Need coverage installed to parse .coverage files. Install it with: pip install "git-pandas[coverage]")
file_change_rates(coverage=True) -> ImportError(Need coverage installed to parse .coverage files. Install it with: pip install "git-pandas[coverage]")
```

`import gitpandas`, `from gitpandas import Repository, ProjectDirectory, GitHubProfile`, and `from gitpandas.cache import EphemeralCache, DiskCache` all succeed there. Before this change the same probe printed `coverage() -> DataFrame (0, 4)`.

**`[redis]` in its own clean venv**: `import redis` → 8.1.0; `RedisDFCache(...)` constructs against a mocked `redis.StrictRedis` (it calls `sync()` in `__init__`, so an unmocked construction reaches a live connection attempt). `coverage` is confirmed still absent under `[redis]` alone.

**`[coverage]` in its own clean venv**: `import coverage` succeeds, `redis` absent, and `coverage()` returns the empty frame for an unparseable `.coverage` file — the genuine "no data" path is unchanged.

**Non-vacuity of the new tests**: with `gitpandas/` stashed (source reverted, new tests kept), `test_coverage_missing_coverage_package` and `test_file_change_rates_missing_coverage_package` both **fail**; they pass with the fix. The third new test (`test_coverage_missing_package_without_coverage_file`) passes either way — it documents that the no-`.coverage`-file path still returns the empty frame and carries no behaviour guard.

`grep -n "redis\|coverage" pyproject.toml` shows both only under `[project.optional-dependencies]`; the remaining hits are the `redis` pytest marker and the `[tool.coverage.run]` config section.

### One pre-existing test needed a one-line change

`test_coverage_permission_denied` patches `os.path.join` globally. With the import inside the try, the `PermissionError` that mock raised was hit by the *coverage package's own import machinery* and caught there — so the test was asserting "any PermissionError anywhere gives an empty frame", never reaching the data-file path. Moving the import out makes that escape. The test now imports `coverage` before applying the patch, so the mock affects only the data-file join it was meant to test. (It was order-dependent before: on master it fails too if `coverage` isn't already in `sys.modules` when it runs.)