### PR TITLE
Fix cumulative_blame output shape: drop label columns, sort index ascending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Unreleased
  * **CHANGED** (user-visible): `redis` and `coverage` are no longer installed by `pip install git-pandas`. Neither is used by the core library — `redis` is imported behind a guard in `gitpandas.cache` and `coverage` is imported lazily inside `Repository.coverage()` — so a plain install no longer pulls in a Redis client and a test-coverage tool. They are now optional extras: install `git-pandas[redis]` to use `RedisDFCache`, and `git-pandas[coverage]` to use `Repository.coverage()` / `Repository.file_change_rates(coverage=True)`. Both are included in the `all` and `dev` extras. **Anyone relying on `RedisDFCache` after a bare `pip install git-pandas` must now install `git-pandas[redis]`**; the failure mode is the existing explicit `ImportError("Need redis installed to use redis cache")`.
  * **FIXED**: `Repository.coverage()` swallowed a missing `coverage` package. The `import coverage` sat inside a `try` whose final handler is a broad `except Exception`, so on a repository that *does* have a `.coverage` file the result was an empty DataFrame — indistinguishable from "no coverage data". The import now happens outside that block and raises an `ImportError` naming the `git-pandas[coverage]` extra. `Repository.file_change_rates(coverage=True)` re-raises it rather than returning an empty frame. Genuine "no coverage data" cases still return the empty DataFrame as before.
 
+### Cumulative Blame Output Shape
+
+**This is a user-visible change to the output of `cumulative_blame` and
+`parallel_cumulative_blame`. Callers that index those frames positionally (`iloc[0]`,
+`columns[0]`) will see different data.**
+
+ * **FIXED**: `Repository.cumulative_blame()` and `Repository.parallel_cumulative_blame()` returned the string `repository` label column (and any `labels_to_add` columns) mixed in with the per-contributor LOC counts, so `df.sum(axis=1)` — total LOC over time — raised `TypeError: can only concatenate str (not "int") to str`. Label columns are now dropped, so the returned columns are exactly the contributor names, matching the columns `ProjectDirectory.cumulative_blame()` already returned.
+ * **FIXED**: All three cumulative blame methods (`Repository.cumulative_blame()`, `Repository.parallel_cumulative_blame()`, `ProjectDirectory.cumulative_blame()`) returned a reverse-chronological (monotonically decreasing) `DatetimeIndex`, because `revs()` yields newest-first and nothing sorted. That made label-based date slicing raise `KeyError: Value based partial slicing on non-monotonic DatetimeIndexes...`, silently negated `.diff()`, and made `.iloc[-1]` the oldest row. The index is now sorted ascending.
+ * **ENHANCED**: The zero-column filter in both `Repository` methods now does a numeric sum instead of an O(n) string concatenation over the label column.
+ * **CHANGED**: When several revisions share one timestamp, `ProjectDirectory.cumulative_blame()` now consistently keeps the newest of them (`index.duplicated(keep="last")` on the ascending index). Previously a single-repository project kept the newest and a multi-repository project kept the oldest, because only the latter was index-sorted by the merge.
+
 v2.5.0
 ======
 

--- a/docs/source/usecases.rst
+++ b/docs/source/usecases.rst
@@ -96,12 +96,16 @@ Track code ownership over time:
 
 .. code-block:: python
 
-    # Get cumulative blame
+    # Get cumulative blame: an ascending DatetimeIndex, one column per contributor
     blame_df = repo.cumulative_blame()
-    
+
+    # Total LOC over time, and growth per revision
+    blame_df.sum(axis=1)
+    blame_df.sum(axis=1).diff()
+
     # Plot cumulative blame using pandas plotting
     import matplotlib.pyplot as plt
-    blame_df.plot(x='date', y='loc', title='Cumulative Blame Over Time')
+    blame_df.plot(kind='area', stacked=True, title='Cumulative Blame Over Time')
     plt.show()
 
 Bus Factor Analysis

--- a/gitpandas/project.py
+++ b/gitpandas/project.py
@@ -831,7 +831,10 @@ class ProjectDirectory:
             include_globs (Optional[List[str]]): List of glob patterns for files to include
 
         Returns:
-            DataFrame: DataFrame with cumulative blame information
+            DataFrame: A DataFrame indexed by an ascending (monotonically increasing)
+                DatetimeIndex named ``date``, with one numeric column per contributor
+                (``by='committer'``) or per repository (``by='project'``). Label columns
+                are not included, so ``df.sum(axis=1)`` gives total LOC.
         """
         logger.info(f"Calculating cumulative blame for branch '{branch or self.default_branch}' grouped by '{by}'.")
         if branch is None:
@@ -872,6 +875,10 @@ class ProjectDirectory:
             blame = blame.rename(columns=lambda x, reponame=reponame: f"{x}__{reponame}")
             global_blame = pd.merge(global_blame, blame, left_index=True, right_index=True, how="outer")
 
+        # the outer merge above sorts, but a single-repo project never reaches it, and the
+        # ffill below only carries a repo's last known blame forward on an ascending index
+        global_blame = global_blame.sort_index()
+
         global_blame = global_blame.ffill()
         global_blame.fillna(0.0, inplace=True)
 
@@ -907,7 +914,9 @@ class ProjectDirectory:
 
             global_blame = global_blame.reindex(columns=list(project_mapping.keys()))
 
-        global_blame = global_blame[~global_blame.index.duplicated()]
+        # keep="last" on an ascending index selects the same row the pre-sort code did:
+        # the newest revision sharing a timestamp
+        global_blame = global_blame[~global_blame.index.duplicated(keep="last")]
 
         logger.info(f"Calculated cumulative blame with {len(global_blame)} time points.")
         return global_blame

--- a/gitpandas/repository.py
+++ b/gitpandas/repository.py
@@ -1326,7 +1326,11 @@ class Repository:
             skip_broken (bool, optional): Whether to skip corrupted Git objects. Defaults to True.
 
         Returns:
-            DataFrame: DataFrame with blame information
+            DataFrame: A DataFrame indexed by an ascending (monotonically increasing)
+                DatetimeIndex named ``date``, with one integer column per contributor
+                holding the lines blamed to them at that revision. Label columns
+                (``repository`` and any ``labels_to_add`` entries) are not included, so
+                the frame is entirely numeric and ``df.sum(axis=1)`` gives total LOC.
 
         Note:
             If both ignore_globs and include_globs are provided, files must match an include
@@ -1350,6 +1354,10 @@ class Repository:
             logger.error("DataFrame returned from self.revs() is missing the 'rev' column.")
             # Raise a specific error to make it clear.
             raise ValueError("Internal Error: self.revs() returned DataFrame without 'rev' column.")
+
+        # the label columns revs() attaches are not part of this method's contract, and a
+        # string column here would poison sum(axis=1) on the result
+        revs = revs.drop(columns=self._label_columns(), errors="ignore")
 
         # get the commit history to stub out committers (hacky and slow)
         logger.debug("Fetching all committers to pre-populate columns...")
@@ -1436,9 +1444,12 @@ class Repository:
             revs.set_index(keys=["date"], drop=True, inplace=True)
             revs = revs.fillna(0.0)
 
+            # revs() yields newest-first; a cumulative series over time must run forwards
+            revs = revs.sort_index()
+
             # drop 0 cols
-            for col in revs.columns.values:
-                if col != "col" and revs[col].sum() == 0:
+            for col in list(revs.columns):
+                if pd.to_numeric(revs[col], errors="coerce").fillna(0).sum() == 0:
                     del revs[col]
 
             # drop 0 rows
@@ -1512,7 +1523,11 @@ class Repository:
             skip_broken (bool, optional): Whether to skip corrupted Git objects. Defaults to True.
 
         Returns:
-            DataFrame: DataFrame with blame information
+            DataFrame: A DataFrame indexed by an ascending (monotonically increasing)
+                DatetimeIndex named ``date``, with one column per contributor holding the
+                lines blamed to them at that revision. Label columns (``repository`` and any
+                ``labels_to_add`` entries) are not included, so the frame is entirely numeric
+                and ``df.sum(axis=1)`` gives total LOC.
         """
         resolved_branch = self.default_branch if branch is None else branch
 
@@ -1537,6 +1552,10 @@ class Repository:
         logger.debug(f"Prepared {len(revs)} revisions for parallel processing.")
 
         try:
+            # the label columns revs() attaches are not part of this method's contract, and a
+            # string column here would poison sum(axis=1) on the result
+            revs = revs.drop(columns=self._label_columns(), errors="ignore")
+
             revisions = json.loads(revs.to_json(orient="index"))
             revisions = [revisions[key] for key in revisions]
 
@@ -1558,9 +1577,12 @@ class Repository:
             revs.set_index(keys=["date"], drop=True, inplace=True)
             revs = revs.fillna(0.0)
 
+            # revs() yields newest-first; a cumulative series over time must run forwards
+            revs = revs.sort_index()
+
             # drop 0 cols
-            for col in revs.columns.values:
-                if col != "col" and revs[col].sum() == 0:
+            for col in list(revs.columns):
+                if pd.to_numeric(revs[col], errors="coerce").fillna(0).sum() == 0:
                     del revs[col]
 
             # drop 0 rows
@@ -1993,6 +2015,14 @@ class Repository:
         for i, label in enumerate(self._labels_to_add):
             df[f"label{i}"] = label
         return df
+
+    def _label_columns(self):
+        """Returns the column names that :meth:`_add_labels_to_df` attaches.
+
+        Returns:
+            List[str]: ``repository`` followed by one ``labelN`` per configured label.
+        """
+        return ["repository"] + [f"label{i}" for i in range(len(self._labels_to_add))]
 
     def __str__(self):
         """Returns a human-readable string representation of the repository.

--- a/gitpandas/utilities/plotting.py
+++ b/gitpandas/utilities/plotting.py
@@ -95,7 +95,9 @@ def plot_cumulative_blame(df):
     Plot cumulative blame information as a stacked area chart.
 
     Args:
-        df (pandas.DataFrame): DataFrame with dates as index and committers as columns
+        df (pandas.DataFrame): DataFrame with an ascending DatetimeIndex of dates and one
+            numeric column per contributor, as returned by ``Repository.cumulative_blame``,
+            ``Repository.parallel_cumulative_blame`` or ``ProjectDirectory.cumulative_blame``
 
     Returns:
         matplotlib.figure.Figure: The generated figure

--- a/tests/test_Project/test_cumulative_blame_output_shape.py
+++ b/tests/test_Project/test_cumulative_blame_output_shape.py
@@ -1,0 +1,127 @@
+"""Regression tests for the shape of ``ProjectDirectory.cumulative_blame``.
+
+The project-level frame inherited the reverse-chronological index from
+``Repository.cumulative_blame``, which broke label-based date slicing and negated
+``.diff()``.
+"""
+
+import datetime
+
+import git
+import pytest
+
+from gitpandas import ProjectDirectory
+from gitpandas.cache import EphemeralCache
+from tests.test_Repository.test_cumulative_blame_output_shape import (
+    ALICE,
+    BOB,
+    DATES,
+    EXPECTED_ALICE,
+    EXPECTED_BOB,
+    EXPECTED_TOTAL,
+    build_blame_repo,
+)
+
+# ProjectDirectory.cumulative_blame(by='committer') lowercases the contributor names
+PROJECT_COLUMNS = sorted([ALICE.lower(), BOB.lower()])
+
+
+@pytest.fixture
+def repo_dir(tmp_path, default_branch):
+    return build_blame_repo(tmp_path / "blame_repo", default_branch)
+
+
+@pytest.fixture(params=[False, True], ids=["uncached", "cached"])
+def project(request, repo_dir, default_branch):
+    cache_backend = EphemeralCache() if request.param else None
+    return ProjectDirectory(
+        working_dir=[str(repo_dir)],
+        default_branch=default_branch,
+        cache_backend=cache_backend,
+        verbose=False,
+    )
+
+
+@pytest.fixture
+def blame_frame(project, default_branch):
+    return project.cumulative_blame(branch=default_branch)
+
+
+class TestProjectCumulativeBlameOutputShape:
+    def test_columns_are_contributors_only(self, blame_frame):
+        assert sorted(blame_frame.columns) == PROJECT_COLUMNS
+
+    def test_index_is_ascending(self, blame_frame):
+        assert blame_frame.index.is_monotonic_increasing
+        assert blame_frame.index.tolist() == DATES
+
+    def test_exact_loc_progression(self, blame_frame):
+        assert blame_frame[ALICE.lower()].tolist() == [float(x) for x in EXPECTED_ALICE]
+        assert blame_frame[BOB.lower()].tolist() == [float(x) for x in EXPECTED_BOB]
+
+    def test_sum_axis_1_gives_total_loc(self, blame_frame):
+        assert blame_frame.sum(axis=1).tolist() == [float(x) for x in EXPECTED_TOTAL]
+
+    def test_date_slicing_works(self, blame_frame):
+        window = blame_frame.loc["2023-11-17":"2023-11-18"]
+
+        assert window.index.tolist() == DATES[1:3]
+        assert window.sum(axis=1).tolist() == [float(x) for x in EXPECTED_TOTAL[1:3]]
+
+    def test_matches_single_repo_column_semantics(self, project, blame_frame, default_branch):
+        """The project frame carries the same contributors as the per-repo frames."""
+        for repo in project.repos:
+            single = repo.cumulative_blame(branch=default_branch)
+
+            assert sorted(c.lower() for c in single.columns) == sorted(blame_frame.columns)
+            assert single.index.tolist() == blame_frame.index.tolist()
+
+
+def _build_staggered_repo(repo_dir, default_branch, name, steps):
+    """Build a repo whose revisions land on the given day offsets with the given line counts."""
+    repo_dir.mkdir(parents=True)
+    repo = git.Repo.init(str(repo_dir))
+    repo.git.config("user.name", "Fallback User")
+    repo.git.config("user.email", "fallback@example.com")
+    repo.git.checkout("-b", default_branch)
+
+    email = f"{name.split()[0].lower()}@example.com"
+    for day_offset, lines in steps:
+        (repo_dir / "src.txt").write_text("".join(f"line {n}\n" for n in range(1, lines + 1)))
+        stamp = f"{int((DATES[0] + datetime.timedelta(days=day_offset)).timestamp())} +0000"
+        repo.git.update_environment(
+            GIT_COMMITTER_NAME=name,
+            GIT_COMMITTER_EMAIL=email,
+            GIT_COMMITTER_DATE=stamp,
+            GIT_AUTHOR_DATE=stamp,
+        )
+        repo.git.add(all=True)
+        repo.git.commit(m=f"{name} -> {lines}", author=f"{name} <{email}>", date=stamp)
+
+    return repo_dir
+
+
+class TestMultiRepoCumulativeBlame:
+    """Two repos with revisions at different timestamps, so the forward fill is exercised."""
+
+    @pytest.fixture
+    def staggered_project(self, tmp_path, default_branch):
+        _build_staggered_repo(tmp_path / "alpha", default_branch, ALICE, [(0, 2), (2, 4)])
+        _build_staggered_repo(tmp_path / "beta", default_branch, BOB, [(1, 5)])
+
+        return ProjectDirectory(
+            working_dir=[str(tmp_path / "alpha"), str(tmp_path / "beta")],
+            default_branch=default_branch,
+            verbose=False,
+        )
+
+    def test_forward_fill_runs_chronologically(self, staggered_project, default_branch):
+        frame = staggered_project.cumulative_blame(branch=default_branch)
+
+        assert frame.index.is_monotonic_increasing
+        assert frame.index.tolist() == DATES[:3]
+        # alice has no revision on day 2, so her day-1 count carries forward, not backward
+        assert frame[ALICE.lower()].tolist() == [2.0, 2.0, 4.0]
+        # bob's repo starts on day 2, so day 1 is a zero-filled gap
+        assert frame[BOB.lower()].tolist() == [0.0, 5.0, 5.0]
+        assert frame.sum(axis=1).tolist() == [2.0, 7.0, 9.0]

--- a/tests/test_Repository/test_cumulative_blame_duplicate_dates.py
+++ b/tests/test_Repository/test_cumulative_blame_duplicate_dates.py
@@ -40,4 +40,11 @@ def test_cumulative_blame_preserves_each_revision(tmp_path, method_name, shared_
     )(branch="main")
 
     assert len(result) == len(revs) == 5
-    assert result["Test Author"].tolist() == [5, 4, 3, 2, 1]
+    assert result.index.is_monotonic_increasing
+
+    if shared_timestamp:
+        # every revision shares one timestamp, so sorting is a stable no-op and the
+        # revisions stay in the newest-first order revs() produced them in
+        assert result["Test Author"].tolist() == [5, 4, 3, 2, 1]
+    else:
+        assert result["Test Author"].tolist() == [1, 2, 3, 4, 5]

--- a/tests/test_Repository/test_cumulative_blame_output_shape.py
+++ b/tests/test_Repository/test_cumulative_blame_output_shape.py
@@ -1,0 +1,126 @@
+"""Regression tests for the shape of the cumulative blame frames.
+
+``Repository.cumulative_blame`` and ``Repository.parallel_cumulative_blame`` used to
+return the string ``repository`` label column alongside the per-contributor LOC counts,
+which made ``df.sum(axis=1)`` raise ``TypeError``, and they returned a reverse
+chronological index, which made ``df.loc[a:b]`` raise ``KeyError``.
+"""
+
+import datetime
+
+import git
+import pytest
+
+from gitpandas import Repository
+from gitpandas.cache import EphemeralCache
+
+ALICE = "Alice Dev"
+BOB = "Bob Dev"
+
+# one commit per day, so every timestamp is distinct and label-sliceable
+BASE = datetime.datetime(2023, 11, 16, tzinfo=datetime.timezone.utc)
+DATES = [BASE + datetime.timedelta(days=offset) for offset in range(4)]
+
+# (alice.txt lines, bob.txt lines) after each commit
+EXPECTED_ALICE = [3, 3, 5, 5]
+EXPECTED_BOB = [0, 2, 2, 4]
+EXPECTED_TOTAL = [3, 5, 7, 9]
+
+
+def _commit(repo, message, name, timestamp):
+    email = f"{name.split()[0].lower()}@example.com"
+    stamp = f"{int(timestamp.timestamp())} +0000"
+    repo.git.update_environment(
+        GIT_COMMITTER_NAME=name,
+        GIT_COMMITTER_EMAIL=email,
+        GIT_COMMITTER_DATE=stamp,
+        GIT_AUTHOR_DATE=stamp,
+    )
+    repo.git.commit(m=message, author=f"{name} <{email}>", date=stamp)
+
+
+def build_blame_repo(repo_dir, default_branch):
+    """Build a repo with two contributors and known per-revision line counts."""
+    repo_dir.mkdir(parents=True)
+    repo = git.Repo.init(str(repo_dir))
+    repo.git.config("user.name", "Fallback User")
+    repo.git.config("user.email", "fallback@example.com")
+    repo.git.checkout("-b", default_branch)
+
+    alice_file = repo_dir / "alice.txt"
+    bob_file = repo_dir / "bob.txt"
+
+    def write(path, lines):
+        path.write_text("".join(f"line {n}\n" for n in range(1, lines + 1)))
+
+    steps = [
+        (alice_file, 3, ALICE),
+        (bob_file, 2, BOB),
+        (alice_file, 5, ALICE),
+        (bob_file, 4, BOB),
+    ]
+    for (path, lines, name), timestamp in zip(steps, DATES, strict=True):
+        write(path, lines)
+        repo.git.add(all=True)
+        _commit(repo, f"{name} -> {path.name}:{lines}", name, timestamp)
+
+    return repo_dir
+
+
+@pytest.fixture
+def repo_dir(tmp_path, default_branch):
+    return build_blame_repo(tmp_path / "blame_repo", default_branch)
+
+
+@pytest.fixture(params=[False, True], ids=["uncached", "cached"])
+def repository(request, repo_dir, default_branch):
+    cache_backend = EphemeralCache() if request.param else None
+    repo = Repository(
+        working_dir=str(repo_dir),
+        default_branch=default_branch,
+        cache_backend=cache_backend,
+        labels_to_add=["team-x"],
+    )
+    yield repo
+    repo.__del__()
+
+
+@pytest.fixture(params=["cumulative_blame", "parallel_cumulative_blame"])
+def blame_frame(request, repository, default_branch):
+    return getattr(repository, request.param)(branch=default_branch)
+
+
+class TestCumulativeBlameOutputShape:
+    def test_columns_are_contributors_only(self, blame_frame):
+        """No 'repository' column and no configured label columns."""
+        assert sorted(blame_frame.columns) == [ALICE, BOB]
+
+    def test_index_is_ascending(self, blame_frame):
+        assert blame_frame.index.is_monotonic_increasing
+        assert blame_frame.index.tolist() == DATES
+
+    def test_exact_loc_progression(self, blame_frame):
+        assert blame_frame[ALICE].tolist() == EXPECTED_ALICE
+        assert blame_frame[BOB].tolist() == EXPECTED_BOB
+
+    def test_sum_axis_1_gives_total_loc(self, blame_frame):
+        assert blame_frame.sum(axis=1).tolist() == EXPECTED_TOTAL
+
+    def test_date_slicing_works(self, blame_frame):
+        window = blame_frame.loc["2023-11-17":"2023-11-18"]
+
+        assert window.index.tolist() == DATES[1:3]
+        assert window[ALICE].tolist() == EXPECTED_ALICE[1:3]
+        assert window[BOB].tolist() == EXPECTED_BOB[1:3]
+
+    def test_diff_is_positive_growth(self, blame_frame):
+        """Reverse-chronological ordering silently negated .diff()."""
+        assert blame_frame.sum(axis=1).diff().dropna().tolist() == [2, 2, 2]
+
+    def test_serial_and_parallel_agree(self, repository, default_branch):
+        serial = repository.cumulative_blame(branch=default_branch)
+        parallel = repository.parallel_cumulative_blame(branch=default_branch)
+
+        assert sorted(serial.columns) == sorted(parallel.columns)
+        assert serial.index.tolist() == parallel.index.tolist()
+        assert serial.sum(axis=1).tolist() == parallel.sum(axis=1).tolist()


### PR DESCRIPTION
Closes #76

`cumulative_blame` documents itself as returning "a DataFrame with dates as index and committers as columns". Two defects made that frame unusable for the two most obvious downstream operations. Both are fixed here, scoped to the three `cumulative_blame` implementations.

## What changed

**1. Label columns are dropped (`Repository.cumulative_blame`, `Repository.parallel_cumulative_blame`)**

`self.revs(...)` attaches the string `repository` column via `_add_labels_to_df`, and neither method removed it, so `df.sum(axis=1)` — total LOC over time — raised `TypeError: can only concatenate str (not "int") to str`. The new `Repository._label_columns()` helper names `repository` plus any `labelN` from `labels_to_add`, and both methods drop those columns.

The drop happens *before* the per-contributor columns are populated, so a contributor literally named `repository` still gets their own column with the correct counts (verified on a fixture).

`ProjectDirectory.cumulative_blame` already returned contributor-only columns as a side effect of its `pd.to_numeric(errors="raise")` filter, so this brings the single-repo layer to parity rather than changing the project layer.

**2. The zero-column filter does arithmetic**

`revs[col].sum() == 0` on the object-dtype `repository` column was an O(n) string concatenation that never equalled `0`. It now coerces with `pd.to_numeric(..., errors="coerce")` first.

**3. The index is sorted ascending (all three methods)**

`revs()` returns newest-first and nothing sorted, so the `DatetimeIndex` was monotonically *decreasing*. That made `df.loc['2023-11-17':'2023-11-19']` raise `KeyError: Value based partial slicing on non-monotonic DatetimeIndexes...`, silently negated `.diff()`, and made `.iloc[-1]` the oldest row.

**4. Docstrings** on all three methods and on `plot_cumulative_blame` now state the contract explicitly: ascending `DatetimeIndex`, one numeric column per contributor, no label columns.

## Two notes on judgment calls

- **`ProjectDirectory` duplicate timestamps.** The dedup was `~index.duplicated()` (keep first). `pd.merge(how="outer")` already sorted the multi-repo path ascending, but a single-repo project never reaches that merge and kept its descending index — so "keep first" meant *newest* for one repo and *oldest* for several. Now that everything is sorted, `keep="last"` makes both keep the newest, which is the right reading for a cumulative series. This changes the multi-repo duplicate-timestamp case; it's called out in the changelog.
- The `sort_index()` in `project.py` sits before the `ffill()`. I initially wrote this up as a forward-fill bug, then measured it: the outer merge was already sorting the multi-repo path, so the fill was chronologically correct there. The sort is still needed for the single-repo path, but it is not fixing a wrong-values bug in the merged case, and the changelog says so.

## Verification

All commands run from a fresh `uv venv` + `uv pip install -e ".[dev]"`, branch rebased onto current `master` (`7b6fd24`).

**Full gate — green:**
```
MPLBACKEND=Agg .venv/bin/python -m pytest -m "not slow" -q
  -> 475 passed, 1 deselected
.venv/bin/python -m ruff check .
  -> All checks passed!
```
(472 before this PR's tests; the `redis`/`coverage` extras PR raised the baseline to 436+.)

**Reproduction, before and after.** On a 6-commit fixture with pinned author/committer dates, one commit per day:

Before:
```
cumulative_blame          cols: ['repository', 'A'] | descending index: True
parallel_cumulative_blame cols: ['repository', 'A'] | descending index: True
ProjectDirectory          cols: ['a']               | descending index: True
  sum(axis=1)  -> TypeError: can only concatenate str (not "int") to str
  loc['2023-11-17':'2023-11-19'] -> KeyError: ... non-monotonic DatetimeIndexes ...
```
After: all three return contributor-only columns on an ascending index; `sum(axis=1)` gives `[1, 2, 3, 4, 5, 6]` and the slice returns 3 rows.

**Non-vacuity of the new tests.** `git stash push gitpandas/` (the new test files are untracked, so they survive), then run the three cumulative-blame test files: **38 failed, 4 passed**. `git stash pop` restores green. Which test catches which defect:

| Defect | Tests that go red without the source change |
|---|---|
| String `repository` column | `test_columns_are_contributors_only` (Repository only — the project frame never had it), `test_sum_axis_1_gives_total_loc`, `test_serial_and_parallel_agree` |
| Reverse-chronological index | `test_index_is_ascending`, `test_exact_loc_progression`, `test_date_slicing_works`, `test_diff_is_positive_growth`, `test_matches_single_repo_column_semantics`, and the `distinct-dates` cases of the pre-existing `test_cumulative_blame_duplicate_dates` |

The 4 that pass with the source stashed are the project-level `test_columns_are_contributors_only` (that layer was already correct) and the two `duplicate-dates` cases (a single shared timestamp makes the sort a stable no-op — asserted explicitly in that test rather than left implicit).

Assertions are on exact values, not shape: a two-contributor fixture with known line counts gives `[3, 3, 5, 5]` / `[0, 2, 2, 4]` per timestamp and totals `[3, 5, 7, 9]`. Every test is parametrized cached/uncached per this repo's convention, and the Repository ones are parametrized across both `cumulative_blame` and `parallel_cumulative_blame`.

**Multi-repo coverage.** `TestMultiRepoCumulativeBlame` uses two repos with revisions at *different* timestamps, so the forward fill is actually exercised: alice has no revision on day 2 and her day-1 count carries forward rather than backward.

**Charts still render.** `plot_cumulative_blame` drove `examples/cumulative_blame.py`'s exact call shape against a local fixture (the example itself clones a remote repo): the project frame produced a 23KB PNG, and both `Repository` frames now plot too (26KB each).

**Pre-existing test updated.** `tests/test_Repository/test_cumulative_blame_duplicate_dates.py` asserted `[5, 4, 3, 2, 1]`, which encoded the reverse ordering. It now asserts ascending `[1, 2, 3, 4, 5]` for distinct dates and keeps the old list for the shared-timestamp case, with a comment on why sorting is a no-op there.

**Also fixed:** the `cumulative_blame` snippet in `docs/source/usecases.rst` called `blame_df.plot(x='date', y='loc', ...)` — neither column exists on that frame (and `date` is the index). It now shows `sum(axis=1)` and a stacked area plot.